### PR TITLE
Use HTML sanitizer for messages

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -61,12 +61,14 @@ const ChatArea = memo(({
                     ? 'bg-gradient-to-r from-green-50 to-blue-50 border border-green-200'
                     : 'bg-gray-50 border border-gray-200'
               }`}>
-                <div 
+                <div
                   className="whitespace-pre-wrap text-base leading-relaxed"
                   dangerouslySetInnerHTML={{
-                    __html: sanitizeMessageContent(message.content)
-                      .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-                      .replace(/\*(.*?)\*/g, '<em>$1</em>')
+                    __html: sanitizeMessageContent(
+                      message.content
+                        .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+                        .replace(/\*(.*?)\*/g, '<em>$1</em>')
+                    )
                   }}
                 />
                 

--- a/src/utils/messageUtils.test.js
+++ b/src/utils/messageUtils.test.js
@@ -1,0 +1,17 @@
+import { sanitizeMessageContent } from './messageUtils';
+
+describe('sanitizeMessageContent', () => {
+  it('removes script tags from content', () => {
+    const dirty = '<div>hello</div><script>alert("x")</script>';
+    const clean = sanitizeMessageContent(dirty);
+    expect(clean).toBe('<div>hello</div>');
+  });
+
+  it('strips dangerous attributes', () => {
+    const dirty = '<img src="x" onerror="alert(1)">';
+    const clean = sanitizeMessageContent(dirty);
+    expect(clean).toBe('<img src="x">');
+    expect(clean).not.toMatch(/onerror/i);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Sanitize message content by stripping scripts, inline handlers, and other unsafe tags
- Sanitize rendered chat messages after markdown formatting
- Add tests ensuring scripts and unsafe attributes are removed

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b62ebfd528832aa0132a334fe7c983