### PR TITLE
Fix CSV quote escaping

### DIFF
--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -15,14 +15,15 @@ function getRecentMessages(messages) {
 }
 
 /**
- * Sanitizes text for CSV export by escaping commas and newlines
+ * Sanitizes text for CSV export by escaping commas, newlines and quotes
  * @param {string} text - Text to sanitize
  * @returns {string} - Sanitized text
  */
 function sanitizeForCSV(text) {
-  if (!text) return '';
-  
-  return text
+  if (text === undefined || text === null) return '';
+
+  return String(text)
+    .replace(/"/g, '""')
     .replace(/,/g, ';')
     .replace(/\n/g, ' ')
     .replace(/\r/g, ' ')
@@ -90,14 +91,14 @@ export function exportNotebook(messages) {
     const rows = recentMessages.map(msg => [
       msg.timestamp || '',
       msg.type || '',
-      sanitizeForCSV(msg.content),
+      msg.content || '',
       formatResourcesForExport(msg.resources),
       msg.isStudyNotes ? 'Yes' : 'No'
     ]);
 
-    // Combine headers and rows
+    // Combine headers and rows, escaping each cell and wrapping in quotes
     const csvContent = [headers, ...rows]
-      .map(row => row.map(cell => `"${cell}"`).join(','))
+      .map(row => row.map(cell => `"${sanitizeForCSV(cell)}"`).join(','))
       .join('\n');
 
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });

--- a/src/utils/exportUtils.test.js
+++ b/src/utils/exportUtils.test.js
@@ -1,0 +1,42 @@
+import { exportNotebook } from './exportUtils';
+
+describe('exportNotebook CSV export', () => {
+  it('escapes quotes in messages', async () => {
+    const messages = [{
+      timestamp: new Date().toISOString(),
+      type: 'user',
+      content: 'He said, "Hello"',
+      resources: [],
+      isStudyNotes: false
+    }];
+
+    class MockBlob {
+      constructor(parts) {
+        this.parts = parts;
+      }
+      text() {
+        return Promise.resolve(this.parts.join(''));
+      }
+    }
+    global.Blob = MockBlob;
+
+    let capturedBlob;
+    const createObjectURL = jest.fn(blob => {
+      capturedBlob = blob;
+      return 'blob:mock';
+    });
+    const revokeObjectURL = jest.fn();
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = revokeObjectURL;
+
+    exportNotebook(messages);
+
+    const text = await capturedBlob.text();
+    expect(createObjectURL).toHaveBeenCalled();
+    const expected = [
+      '"Timestamp","Type","Message","Resources","Study Notes"',
+      `"${messages[0].timestamp}","user","He said; ""Hello""","","No"`
+    ].join('\n');
+    expect(text).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- Escape double quotes when sanitizing CSV content
- Quote and sanitize every cell when building CSV rows
- Add tests for exporting messages with quotes

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b62ec40dfc832a95892562bb04db46