### PR TITLE
Fix chat area overflow and layout

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -31,9 +31,9 @@ const ChatArea = memo(({
   };
 
   return (
-    <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 flex flex-col shadow-sm h-full">
+    <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 flex flex-col shadow-sm h-full overflow-hidden">
       {/* Chat Messages - Scrollable window that grows with available space */}
-      <div className="flex-1 overflow-y-auto p-8 space-y-6" style={{ scrollBehavior: 'smooth' }}>
+      <div className="flex-1 overflow-y-auto p-8 space-y-6 min-h-0" style={{ scrollBehavior: 'smooth' }}>
           {messages.length === 0 ? (
             <div className="text-center py-16">
               <div className="w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg mx-auto mb-6 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- prevent ChatArea container from overflowing its grid cell
- allow message list to shrink and scroll without affecting layout

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b778b0bb6c832a8652788d1e195f9b