### PR TITLE
fix: prevent chat input area shrinking

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -119,7 +119,7 @@ const ChatArea = memo(({
         </div>
 
       {/* Input Area - Always visible at bottom */}
-      <div className="border-t border-gray-200 bg-gray-50 p-8">
+      <div className="border-t border-gray-200 bg-gray-50 p-8 flex-shrink-0">
         <form onSubmit={handleSubmit} className="flex space-x-4">
           <div className="flex-1 relative">
             <textarea


### PR DESCRIPTION
## Summary
- ensure chat input wrapper doesn't shrink by adding `flex-shrink-0`
- confirm `textarea` remains non-resizable with bounded height

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b778b789e8832aa6ee4f8f37d6a350