### PR TITLE
fix: constrain chat area container

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -294,9 +294,9 @@ const AcceleraQA = () => {
           exportNotebook={handleExport}
         />
 
-        <div className="max-w-7xl mx-auto px-6 py-8">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 h-[calc(100vh-160px)]">
-            <ChatArea 
+        <div className="max-w-7xl mx-auto px-6 py-8 h-[calc(100vh-160px)]">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 h-full min-h-0 overflow-hidden">
+            <ChatArea
               messages={messages}
               inputMessage={inputMessage}
               setInputMessage={setInputMessage}


### PR DESCRIPTION
## Summary
- ensure the layout wrapping `ChatArea` fills the viewport and doesn't exceed height
- contain overflow so `ChatArea` can scroll internally

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b778bbe3bc832aae72a71baa41fea5