### PR TITLE
fix: keep chat list scrollable

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -31,9 +31,9 @@ const ChatArea = memo(({
   };
 
   return (
-    <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 flex flex-col shadow-sm h-full overflow-hidden">
+    <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 flex flex-col shadow-sm h-full">
       {/* Chat Messages - Scrollable window that grows with available space */}
-      <div className="flex-1 overflow-y-auto p-8 space-y-6 min-h-0" style={{ scrollBehavior: 'smooth' }}>
+      <div className="flex-1 h-full overflow-y-auto p-8 space-y-6 min-h-0" style={{ scrollBehavior: 'smooth' }}>
           {messages.length === 0 ? (
             <div className="text-center py-16">
               <div className="w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg mx-auto mb-6 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- remove `overflow-hidden` from chat container so content can overflow
- ensure message list grows and scrolls with `h-full overflow-y-auto`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b77b616fd0832aae238d65180de428