### PR TITLE
fix: align chat area height with header

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -294,7 +294,7 @@ const AcceleraQA = () => {
           exportNotebook={handleExport}
         />
 
-        <div className="max-w-7xl mx-auto px-6 py-8 h-[calc(100vh-160px)]">
+        <div className="max-w-7xl mx-auto px-6 py-8 h-[calc(100vh-64px)]">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 h-full min-h-0 overflow-hidden">
             <ChatArea
               messages={messages}


### PR DESCRIPTION
## Summary
- ensure chat layout subtracts header height from viewport to avoid overlap

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b77b637244832abeeb71045ea0b36b