### PR TITLE
fix: allow page scrolling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -295,7 +295,7 @@ const AcceleraQA = () => {
         />
 
         <div className="max-w-7xl mx-auto px-6 py-8 h-[calc(100vh-64px)]">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 h-full min-h-0 overflow-hidden">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 h-full min-h-0">
             <ChatArea
               messages={messages}
               inputMessage={inputMessage}


### PR DESCRIPTION
## Summary
- remove `overflow-hidden` from chat/sidebar grid to restore default browser scrolling

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b782488cd0832a8c39d2e2a7954673