### PR TITLE
feat: enhance landing page marketing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,16 +5,16 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚗️</text></svg>" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="AI learning assistant for pharmaceutical quality and compliance professionals" />
+    <meta name="description" content="Interactive AI learning assistant for pharmaceutical quality professionals that accelerates upskilling and enables direct interaction with industry documents" />
     
     <meta property="og:title" content="AcceleraQA - Pharmaceutical Quality & Compliance AI" />
-    <meta property="og:description" content="AI-powered learning assistant for pharmaceutical quality and compliance professionals" />
+    <meta property="og:description" content="Interactive AI learning assistant for pharmaceutical quality professionals. Upskill faster and engage with industry documents." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="%PUBLIC_URL%/og-image.png" />
     
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="AcceleraQA - Pharmaceutical Quality & Compliance AI" />
-    <meta name="twitter:description" content="AI-powered learning assistant for pharmaceutical quality and compliance professionals" />
+    <meta name="twitter:description" content="Interactive AI learning assistant for pharmaceutical quality professionals. Upskill faster and engage with industry documents." />
     
     <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚗️</text></svg>" />
     

--- a/src/components/AuthScreen.js
+++ b/src/components/AuthScreen.js
@@ -51,23 +51,15 @@ const AuthScreen = memo(() => {
         <div className="max-w-7xl mx-auto px-6 py-4">
           <div className="flex items-center justify-between">
             <div className="text-2xl font-bold tracking-tight">AcceleraQA</div>
-            <div className="flex items-center gap-3">
-              <button
-                onClick={handleEvaluationClick}
-                className="px-4 py-2 bg-gradient-to-r from-green-600 to-emerald-600 text-white font-medium rounded hover:from-green-700 hover:to-emerald-700 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-green-300 flex items-center gap-2"
-                aria-label="Request evaluation of AcceleraQA"
-              >
-                <span>🔬</span>
-                <span>Request Evaluation</span>
-              </button>
-              <button
-                onClick={handleLoginClick}
-                className="px-6 py-2 bg-white text-black font-medium rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
-                aria-label="Sign in to AcceleraQA"
-              >
-                Sign In
-              </button>
-            </div>
+          <div className="flex items-center">
+            <button
+              onClick={handleLoginClick}
+              className="px-6 py-2 bg-white text-black font-medium rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
+              aria-label="Sign in to AcceleraQA"
+            >
+              Sign In
+            </button>
+          </div>
           </div>
         </div>
       </header>
@@ -83,8 +75,8 @@ const AuthScreen = memo(() => {
           </h1>
           
           <p className="text-xl lg:text-2xl text-gray-300 mb-12 leading-relaxed max-w-3xl">
-            AI-powered learning assistant for pharmaceutical quality and compliance professionals. 
-            Accelerating innovation in regulatory excellence through intelligent automation.
+            AcceleraQA is an interactive AI learning assistant built for pharmaceutical quality professionals.
+            Upskill faster through dynamic conversations and engage directly with industry documents.
           </p>
 
           {/* Main CTA Section */}
@@ -126,22 +118,22 @@ const AuthScreen = memo(() => {
             <FeatureCard
               icon={<MessageSquare className="h-8 w-8" />}
               gradient="from-blue-600 to-purple-600"
-              title="Intelligent Responses"
-              description="Advanced AI understanding of pharmaceutical regulations, GMP standards, and compliance requirements with real-time learning capabilities."
+              title="Interactive Learning"
+              description="Dynamic conversations that adapt to your quality questions in real time."
             />
-            
+
             <FeatureCard
               icon={<BookOpen className="h-8 w-8" />}
               gradient="from-purple-600 to-pink-600"
-              title="Curated Learning"
-              description="Dynamic resource recommendations from FDA, ICH, and industry leaders for continuous professional development and regulatory updates."
+              title="Faster Upskilling"
+              description="Personalized guidance and curated resources to accelerate your expertise."
             />
-            
+
             <FeatureCard
               icon={<FileText className="h-8 w-8" />}
               gradient="from-pink-600 to-red-600"
-              title="Export & Analyze"
-              description="Generate comprehensive study materials and export conversation data for team collaboration and knowledge sharing."
+              title="Industry Document Chat"
+              description="Upload and interact with FDA, ICH, and company documents for instant answers."
             />
           </div>
 


### PR DESCRIPTION
## Summary
- highlight interactive, document-ready learning in hero copy
- showcase interactive learning, faster upskilling, and document chat features
- update meta descriptions for improved sign-up appeal
- remove Request Evaluation button from header while keeping main-page CTA

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b8a79daf0c832aa824ccf01089c747