### PR TITLE
feat: refresh ui to match brand

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚗️</text></svg>" />
+    <link rel="icon" href="%PUBLIC_URL%/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Interactive AI learning assistant for pharmaceutical quality professionals that accelerates upskilling and enables direct interaction with industry documents" />
@@ -16,7 +16,7 @@
     <meta name="twitter:title" content="AcceleraQA - Pharmaceutical Quality & Compliance AI" />
     <meta name="twitter:description" content="Interactive AI learning assistant for pharmaceutical quality professionals. Upskill faster and engage with industry documents." />
     
-    <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚗️</text></svg>" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.svg" />
     
     <link rel="preconnect" href="https://api.openai.com" />
     <link rel="dns-prefetch" href="https://api.openai.com" />

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" fill="none">
+  <defs>
+    <linearGradient id="aqGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#3B82F6"/>
+    </linearGradient>
+  </defs>
+  <!-- Rocket icon -->
+  <g transform="translate(0,2)" stroke="url(#aqGradient)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 0c-6 2-12 8-12 14 0 5 4 12 12 24 8-12 12-19 12-24 0-6-6-12-12-14z" fill="none"/>
+    <path d="M20 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8z" fill="url(#aqGradient)" stroke="none"/>
+    <path d="M20 22c-3 4-4 6-4 8h8c0-2-1-4-4-8z" fill="url(#aqGradient)" stroke="none"/>
+  </g>
+  <!-- Text -->
+  <text x="50" y="28" font-family="Helvetica, Arial, sans-serif" font-size="24" fill="url(#aqGradient)">AcceleraQA</text>
+</svg>

--- a/src/App.js
+++ b/src/App.js
@@ -474,8 +474,8 @@ const AcceleraQA = () => {
   // Main authenticated interface
   return (
     <ErrorBoundary>
-      <div className="min-h-screen bg-gray-50">
-        <Header 
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-gray-100">
+        <Header
           user={user}
           showNotebook={showNotebook}
           setShowNotebook={setShowNotebook}

--- a/src/components/AuthScreen.js
+++ b/src/components/AuthScreen.js
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { User, ChevronRight, MessageSquare, BookOpen, FileText, Shield } from 'lucide-react';
+import { User, ChevronRight, MessageSquare, BookOpen, FileText, Shield, Rocket } from 'lucide-react';
 import { handleLogin } from '../services/authService';
 
 const AuthScreen = memo(() => {
@@ -45,21 +45,24 @@ const AuthScreen = memo(() => {
   };
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white">
       {/* Header */}
       <header className="border-b border-gray-800">
         <div className="max-w-7xl mx-auto px-6 py-4">
           <div className="flex items-center justify-between">
-            <div className="text-2xl font-bold tracking-tight">AcceleraQA</div>
-          <div className="flex items-center">
-            <button
-              onClick={handleLoginClick}
-              className="px-6 py-2 bg-white text-black font-medium rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
-              aria-label="Sign in to AcceleraQA"
-            >
-              Sign In
-            </button>
-          </div>
+            <div className="flex items-center space-x-2">
+              <Rocket className="h-6 w-6 text-primary-light" />
+              <span className="text-2xl font-bold tracking-tight bg-gradient-to-r from-primary-light to-primary bg-clip-text text-transparent">AcceleraQA</span>
+            </div>
+            <div className="flex items-center">
+              <button
+                onClick={handleLoginClick}
+                className="px-6 py-2 bg-white text-black font-medium rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
+                aria-label="Sign in to AcceleraQA"
+              >
+                Sign In
+              </button>
+            </div>
           </div>
         </div>
       </header>
@@ -69,7 +72,7 @@ const AuthScreen = memo(() => {
         <div className="max-w-4xl">
           <h1 className="text-6xl lg:text-8xl font-bold mb-8 leading-tight">
             The Future of
-            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500">
+            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-primary-light to-primary">
               Pharmaceutical QA
             </span>
           </h1>

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -31,35 +31,35 @@ const ChatArea = memo(({
   };
 
   return (
-    <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 flex flex-col shadow-sm h-full">
+    <div className="lg:col-span-2 bg-gray-900/60 backdrop-blur-sm rounded-lg border border-gray-700 flex flex-col shadow-lg h-full text-gray-100">
       {/* Chat Messages - Scrollable window that grows with available space */}
       <div className="flex-1 h-full overflow-y-auto p-8 space-y-6 min-h-0" style={{ scrollBehavior: 'smooth' }}>
           {messages.length === 0 ? (
             <div className="text-center py-16">
-              <div className="w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg mx-auto mb-6 flex items-center justify-center">
+              <div className="w-16 h-16 bg-gradient-to-r from-primary to-primary-light rounded-lg mx-auto mb-6 flex items-center justify-center">
                 <MessageSquare className="h-8 w-8 text-white" />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Welcome to AcceleraQA</h3>
-              <p className="text-gray-600 mb-8 text-lg">
+              <h3 className="text-2xl font-bold text-gray-100 mb-4">Welcome to AcceleraQA</h3>
+              <p className="text-gray-400 mb-8 text-lg">
                 Ask questions about pharmaceutical quality and compliance topics
               </p>
               <div className="flex flex-wrap justify-center gap-3">
-                <span className="px-4 py-2 bg-blue-50 text-blue-700 rounded-full font-medium">GMP</span>
-                <span className="px-4 py-2 bg-purple-50 text-purple-700 rounded-full font-medium">Validation</span>
-                <span className="px-4 py-2 bg-green-50 text-green-700 rounded-full font-medium">CAPA</span>
-                <span className="px-4 py-2 bg-orange-50 text-orange-700 rounded-full font-medium">Regulatory</span>
-                <span className="px-4 py-2 bg-pink-50 text-pink-700 rounded-full font-medium">Risk Management</span>
+                <span className="px-4 py-2 bg-primary/20 text-primary-light rounded-full font-medium">GMP</span>
+                <span className="px-4 py-2 bg-primary/20 text-primary-light rounded-full font-medium">Validation</span>
+                <span className="px-4 py-2 bg-primary/20 text-primary-light rounded-full font-medium">CAPA</span>
+                <span className="px-4 py-2 bg-primary/20 text-primary-light rounded-full font-medium">Regulatory</span>
+                <span className="px-4 py-2 bg-primary/20 text-primary-light rounded-full font-medium">Risk Management</span>
               </div>
             </div>
           ) : (
             messages.map((message) => (
               <div key={message.id} className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}>
                 <div className={`max-w-3xl px-6 py-4 rounded-lg ${
-                  message.type === 'user' 
-                    ? 'bg-black text-white' 
+                  message.type === 'user'
+                    ? 'bg-primary text-white'
                     : message.isStudyNotes
-                      ? 'bg-gradient-to-r from-green-50 to-blue-50 border border-green-200'
-                      : 'bg-gray-50 border border-gray-200'
+                      ? 'bg-gradient-to-r from-primary-dark to-primary border border-primary text-white'
+                      : 'bg-gray-800 border border-gray-700 text-gray-100'
                 }`}>
                   <div 
                     className="whitespace-pre-wrap text-base leading-relaxed"
@@ -73,24 +73,24 @@ const ChatArea = memo(({
                   {message.type === 'ai' && (
                     <div className={`flex items-center justify-between mt-3 pt-3 border-t ${
                       message.isStudyNotes
-                        ? 'border-green-200 text-gray-500'
-                        : 'border-gray-200 text-gray-500'
+                        ? 'border-primary text-gray-300'
+                        : 'border-gray-700 text-gray-400'
                     }`}>
                       <div className="flex items-center space-x-3">
                         <time className="text-xs" dateTime={message.timestamp}>
                           {new Date(message.timestamp).toLocaleString()}
                         </time>
                         {message.isStudyNotes && (
-                          <span className="text-xs text-green-600 font-medium">
+                          <span className="text-xs text-primary-light font-medium">
                             📚 Study Notes
                           </span>
                         )}
                       </div>
-                      
+
                       {message.isStudyNotes && (
                         <button
                           onClick={() => handleExportStudyNotes(message)}
-                          className="ml-3 px-3 py-1 bg-black text-white text-xs rounded hover:bg-gray-800 transition-colors flex items-center space-x-1 focus:outline-none focus:ring-2 focus:ring-gray-600"
+                          className="ml-3 px-3 py-1 bg-primary text-white text-xs rounded hover:bg-primary-dark transition-colors flex items-center space-x-1 focus:outline-none focus:ring-2 focus:ring-primary-light"
                           aria-label="Export study notes to Word document"
                         >
                           <FileText className="h-3 w-3" />
@@ -106,10 +106,10 @@ const ChatArea = memo(({
 
           {isLoading && (
             <div className="flex justify-start">
-              <div className="bg-gray-50 border border-gray-200 px-6 py-4 rounded-lg">
+              <div className="bg-gray-800 border border-gray-700 px-6 py-4 rounded-lg">
                 <div className="flex items-center space-x-3">
-                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-black" />
-                  <span className="text-gray-700">Analyzing your question...</span>
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary-light" />
+                  <span className="text-gray-300">Analyzing your question...</span>
                 </div>
               </div>
             </div>
@@ -119,7 +119,7 @@ const ChatArea = memo(({
         </div>
 
       {/* Input Area - Always visible at bottom */}
-      <div className="border-t border-gray-200 bg-gray-50 p-8 flex-shrink-0">
+      <div className="border-t border-gray-700 bg-gray-900 p-8 flex-shrink-0">
         <form onSubmit={handleSubmit} className="flex space-x-4">
           <div className="flex-1 relative">
             <textarea
@@ -127,7 +127,7 @@ const ChatArea = memo(({
               onChange={handleInputChange}
               onKeyDown={handleKeyPress}
               placeholder="Ask about GMP, validation, CAPA, regulations..."
-              className="w-full px-4 py-4 border border-gray-300 rounded-lg focus:ring-2 focus:ring-black focus:border-transparent text-base resize-none min-h-[60px] max-h-32"
+              className="w-full px-4 py-4 bg-gray-800 border border-gray-700 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent text-base text-gray-100 placeholder-gray-500 resize-none min-h-[60px] max-h-32"
               disabled={isLoading}
               rows={1}
               aria-label="Enter your pharmaceutical quality question"
@@ -144,33 +144,33 @@ const ChatArea = memo(({
           <button
             type="submit"
             disabled={isLoading || !inputMessage.trim()}
-            className="px-8 py-4 bg-black text-white rounded-lg hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-gray-600 flex-shrink-0"
+            className="px-8 py-4 bg-primary text-white rounded-lg hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-primary-light flex-shrink-0"
             aria-label="Send message"
           >
             <Send className="h-5 w-5" />
           </button>
         </form>
-        
+
         {/* Quick action suggestions when no messages */}
         {messages.length === 0 && (
           <div className="mt-4 flex flex-wrap gap-2">
             <button
               onClick={() => setInputMessage("What are the key requirements for GMP compliance?")}
-              className="text-sm px-3 py-1 bg-white border border-gray-300 rounded-full hover:bg-gray-50 transition-colors"
+              className="text-sm px-3 py-1 bg-gray-800 border border-gray-700 text-gray-200 rounded-full hover:bg-gray-700 transition-colors"
               disabled={isLoading}
             >
               GMP compliance requirements
             </button>
             <button
               onClick={() => setInputMessage("How do I develop a validation master plan?")}
-              className="text-sm px-3 py-1 bg-white border border-gray-300 rounded-full hover:bg-gray-50 transition-colors"
+              className="text-sm px-3 py-1 bg-gray-800 border border-gray-700 text-gray-200 rounded-full hover:bg-gray-700 transition-colors"
               disabled={isLoading}
             >
               Validation master plan
             </button>
             <button
               onClick={() => setInputMessage("What is the CAPA process?")}
-              className="text-sm px-3 py-1 bg-white border border-gray-300 rounded-full hover:bg-gray-50 transition-colors"
+              className="text-sm px-3 py-1 bg-gray-800 border border-gray-700 text-gray-200 rounded-full hover:bg-gray-700 transition-colors"
               disabled={isLoading}
             >
               CAPA process

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import React, { memo, useState, useEffect } from 'react';
-import { Download, Clock, MessageSquare, LogOut, User, Database, AlertTriangle, CheckCircle } from 'lucide-react';
+import { Download, Clock, MessageSquare, LogOut, User, Database, AlertTriangle, CheckCircle, Rocket } from 'lucide-react';
 import { handleLogout } from '../services/authService';
 import { getStorageStats, getStorageHealthReport, performStorageMaintenance, clearStorageData } from '../utils/storageUtils';
 
@@ -138,12 +138,15 @@ const Header = memo(({
   };
 
   return (
-    <header className="bg-black text-white border-b border-gray-800">
+    <header className="bg-gradient-to-r from-gray-900 via-gray-800 to-black text-white border-b border-gray-800 shadow">
       <div className="max-w-7xl mx-auto px-6">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-4">
-            <div className="text-2xl font-bold tracking-tight">AcceleraQA</div>
-            <div className="hidden md:block text-sm text-gray-400">
+            <div className="flex items-center space-x-2">
+              <Rocket className="h-6 w-6 text-primary-light" />
+              <span className="text-2xl font-bold tracking-tight bg-gradient-to-r from-primary-light to-primary bg-clip-text text-transparent">AcceleraQA</span>
+            </div>
+            <div className="hidden md:block text-sm text-primary-light/70">
               Pharmaceutical Quality & Compliance AI
             </div>
           </div>

--- a/src/components/LoadingScreen.js
+++ b/src/components/LoadingScreen.js
@@ -2,13 +2,13 @@ import React, { memo } from 'react';
 
 const LoadingScreen = memo(() => {
   return (
-    <div className="min-h-screen bg-black text-white flex items-center justify-center">
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white flex items-center justify-center">
       <div className="text-center">
         <div className="relative mb-8">
-          <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-white mx-auto"></div>
-          <div className="animate-pulse rounded-full h-12 w-12 bg-white opacity-20 absolute top-2 left-1/2 transform -translate-x-1/2"></div>
+          <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-primary-light mx-auto"></div>
+          <div className="animate-pulse rounded-full h-12 w-12 bg-primary-light opacity-20 absolute top-2 left-1/2 transform -translate-x-1/2"></div>
         </div>
-        <h2 className="text-2xl font-bold mb-4">AcceleraQA</h2>
+        <h2 className="text-2xl font-bold mb-4 bg-gradient-to-r from-primary-light to-primary text-transparent bg-clip-text">AcceleraQA</h2>
         <p className="text-lg text-gray-300 mb-2">Loading your pharmaceutical AI assistant...</p>
         <p className="text-sm text-gray-500">Initializing secure authentication</p>
       </div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -22,15 +22,8 @@ const Sidebar = memo(({
 
   return (
     <div className="lg:col-span-1">
-      {/* Debug indicator */}
-      <div className="bg-yellow-100 border border-yellow-300 p-2 mb-2 text-xs">
-        <strong>Sidebar Debug:</strong><br />
-        Mode: {showNotebook ? 'Notebook' : 'Resources'}<br />
-        Messages: {messages?.length || 0} | ThirtyDay: {thirtyDayMessages?.length || 0}
-      </div>
-      
       {showNotebook ? (
-        <NotebookView 
+        <NotebookView
           messages={messages}
           thirtyDayMessages={thirtyDayMessages}
           selectedMessages={selectedMessages}
@@ -39,8 +32,8 @@ const Sidebar = memo(({
           isGeneratingNotes={isGeneratingNotes}
         />
       ) : (
-        <ResourcesView 
-          currentResources={currentResources} 
+        <ResourcesView
+          currentResources={currentResources}
         />
       )}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: radial-gradient(circle at 25% 25%, #1e293b, #0f172a 70%);
+  color: #f1f5f9;
 }
 
 code {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,15 @@ module.exports = {
     "./public/index.html"
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#4338ca',
+          dark: '#312e81',
+          light: '#6366f1',
+        },
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add rocket logo and reference new favicon
- introduce primary brand colors in Tailwind
- restyle layout, header, chat, auth, and loading screens with dark gradient theme

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b8b51295a0832abe11fd841f267a52