### PR TITLE
Use original logo in header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import React, { memo, useState, useEffect } from 'react';
-import { Download, Clock, MessageSquare, LogOut, User, Database, AlertTriangle, CheckCircle, Rocket } from 'lucide-react';
+import { Download, Clock, MessageSquare, LogOut, User, Database, AlertTriangle, CheckCircle } from 'lucide-react';
 import { handleLogout } from '../services/authService';
 import { getStorageStats, getStorageHealthReport, performStorageMaintenance, clearStorageData } from '../utils/storageUtils';
 
@@ -142,9 +142,8 @@ const Header = memo(({
       <div className="max-w-7xl mx-auto px-6">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-4">
-            <div className="flex items-center space-x-2">
-              <Rocket className="h-6 w-6 text-primary-light" />
-              <span className="text-2xl font-bold tracking-tight bg-gradient-to-r from-primary-light to-primary bg-clip-text text-transparent">AcceleraQA</span>
+            <div className="flex items-center">
+              <img src="/logo.svg" alt="AcceleraQA logo" className="h-8 w-auto" />
             </div>
             <div className="hidden md:block text-sm text-primary-light/70">
               Pharmaceutical Quality & Compliance AI


### PR DESCRIPTION
## Summary
- Replace Rocket icon with original `logo.svg` to show brand image in header

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8e233dc832a95c0be451b6081ff