### PR TITLE
feat: use PNG logo and standardize dimensions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/logo.svg" />
+    <link rel="icon" href="%PUBLIC_URL%/AceleraQA_logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Interactive AI learning assistant for pharmaceutical quality professionals that accelerates upskilling and enables direct interaction with industry documents" />
@@ -16,7 +16,7 @@
     <meta name="twitter:title" content="AcceleraQA - Pharmaceutical Quality & Compliance AI" />
     <meta name="twitter:description" content="Interactive AI learning assistant for pharmaceutical quality professionals. Upskill faster and engage with industry documents." />
     
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.svg" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/AceleraQA_logo.png" />
     
     <link rel="preconnect" href="https://api.openai.com" />
     <link rel="dns-prefetch" href="https://api.openai.com" />

--- a/src/components/AuthScreen.js
+++ b/src/components/AuthScreen.js
@@ -51,9 +51,10 @@ const AuthScreen = memo(() => {
         <div className="max-w-7xl mx-auto px-6 py-4">
           <div className="flex items-center justify-between">
             <img
-              src="/logo.svg"
+              src="/AceleraQA_logo.png"
               alt="AcceleraQA logo"
-              className="h-8 w-auto"
+              width="200"
+              height="40"
             />
             <div className="flex items-center">
               <button

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -144,7 +144,12 @@ const Header = memo(({
           <div className="flex items-center space-x-4">
             <div className="flex items-center">
 
-              <img src="/logo.svg" alt="AcceleraQA logo" className="h-8 w-auto" />
+              <img
+                src="/AceleraQA_logo.png"
+                alt="AcceleraQA logo"
+                width="200"
+                height="40"
+              />
 
             </div>
             <div className="hidden md:block text-sm text-primary-light/70">

--- a/src/components/LoadingScreen.js
+++ b/src/components/LoadingScreen.js
@@ -9,9 +9,11 @@ const LoadingScreen = memo(() => {
           <div className="animate-pulse rounded-full h-12 w-12 bg-primary-light opacity-20 absolute top-2 left-1/2 transform -translate-x-1/2"></div>
         </div>
         <img
-          src="/logo.svg"
+          src="/AceleraQA_logo.png"
           alt="AcceleraQA logo"
-          className="h-8 w-auto mx-auto mb-4"
+          width="200"
+          height="40"
+          className="mx-auto mb-4"
         />
         <p className="text-lg text-gray-300 mb-2">Loading your pharmaceutical AI assistant...</p>
         <p className="text-sm text-gray-500">Initializing secure authentication</p>


### PR DESCRIPTION
## Summary
- replace SVG references with original AceleraQA PNG logo
- ensure logo renders at 200x40 across headers and loading screen
- update favicon and Apple touch icon to PNG

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b8cc413558832a83cea22d0bd15ceb