### PR TITLE
Add JWT dependencies to Netlify functions bundle

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -54,7 +54,7 @@
 
 # Function settings - Updated for ES Modules and Neon
 [functions]
-  external_node_modules = ["@neondatabase/serverless", "mammoth"]
+  external_node_modules = ["@neondatabase/serverless", "mammoth", "jsonwebtoken", "jwks-rsa"]
   node_bundler = "esbuild"
   directory = "netlify/functions"
 


### PR DESCRIPTION
## Summary
- ensure Netlify bundles `jsonwebtoken` and `jwks-rsa` by listing them in `external_node_modules`

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run netlify:build` *(fails: site ID not linked)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2e066838832a97b9dc285386eea6