### PR TITLE
Remove duplicate jwksUri from JWKS client configuration

### DIFF
--- a/netlify/functions/neon-rag-fixed.js
+++ b/netlify/functions/neon-rag-fixed.js
@@ -9,8 +9,7 @@ const client = jwksClient({
   timeout: 30000,
   cache: true,
   rateLimit: true,
-  jwksRequestsPerMinute: 5,
-  jwksUri: `https://${process.env.REACT_APP_AUTH0_DOMAIN}/.well-known/jwks.json`
+  jwksRequestsPerMinute: 5
 });
 
 function getKey(header, callback) {


### PR DESCRIPTION
## Summary
- remove duplicate `jwksUri` in Auth0 JWKS client configuration

## Testing
- `node --check netlify/functions/neon-rag-fixed.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb2e02ba80832a927924f2d0b7629d