### PR TITLE
Fix conversation stats error handling and cleanup braces

### DIFF
--- a/netlify/functions/conversations-blob.js
+++ b/netlify/functions/conversations-blob.js
@@ -187,19 +187,17 @@ async function resetUserConversationStats(userId) {
   try {
     const userStore = getUserStore();
     const statsKey = `${userId}/conversation_stats`;
-    
+
     const resetStats = {
       conversations: 0,
       messages: 0,
       ragConversations: 0,
       lastUpdated: new Date().toISOString()
     };
-    
+
     await userStore.set(statsKey, JSON.stringify(resetStats));
   } catch (error) {
     console.warn('Error resetting user conversation stats:', error);
-  }
-};
   }
 }
 
@@ -362,4 +360,6 @@ async function getConversationStats(userId) {
     };
   } catch (error) {
     console.error('Error getting conversation stats:', error);
-    throw error
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Remove stray braces from `resetUserConversationStats`
- Ensure `getConversationStats` throws errors and closes correctly

## Testing
- `node --check netlify/functions/conversations-blob.js`
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2e002108832aab0411d1bca735a3