### PR TITLE
Improve readability for RAG config form fields

### DIFF
--- a/src/components/RAGConfigurationPage.js
+++ b/src/components/RAGConfigurationPage.js
@@ -604,26 +604,26 @@ const RAGConfigurationPage = ({ user, onClose }) => {
 
                   <div className="space-y-4">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <label className="block text-sm font-medium text-gray-900 mb-1">
                         Title
                       </label>
                       <input
                         type="text"
                         value={uploadMetadata.title}
                         onChange={(e) => setUploadMetadata(prev => ({ ...prev, title: e.target.value }))}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 placeholder-gray-500"
                         placeholder="Document title"
                       />
                     </div>
 
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <label className="block text-sm font-medium text-gray-900 mb-1">
                         Category
                       </label>
                       <select
                         value={uploadMetadata.category}
                         onChange={(e) => setUploadMetadata(prev => ({ ...prev, category: e.target.value }))}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
                       >
                         <option value="general">General</option>
                         <option value="gmp">GMP</option>


### PR DESCRIPTION
## Summary
- Darken title and category field labels and input text for better readability on RAG configuration screen

## Testing
- `npm test --silent -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb34ed8b7c832aafcdbbd07ccf9607