### PR TITLE
Handle JWE tokens when extracting x-user-id

### DIFF
--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -58,6 +58,19 @@ class RAGService {
             } else {
               console.warn('No sub field in JWT token');
             }
+          } else if (tokenParts.length === 5) {
+            console.log('Encrypted token detected - fetching user profile for x-user-id');
+            try {
+              const user = await authService.getUser();
+              if (user?.sub) {
+                headers['x-user-id'] = user.sub;
+                console.log('Added x-user-id header from profile for encrypted token:', user.sub.substring(0, 10) + '...');
+              } else {
+                console.warn('Could not retrieve user profile for x-user-id');
+              }
+            } catch (profileError) {
+              console.warn('Error fetching user profile for x-user-id:', profileError.message);
+            }
           } else {
             console.warn('Invalid JWT format - parts:', tokenParts.length);
             try {


### PR DESCRIPTION
## Summary
- Detect JWE tokens with five segments in `makeAuthenticatedRequest`
- Skip JWT payload decoding for encrypted tokens and use user profile for `x-user-id`
- Log when an encrypted token is detected and a profile lookup supplies the user ID

## Testing
- `npm test`
- `node - <<'NODE' ...` (simulate 5-segment token)


------
https://chatgpt.com/codex/tasks/task_e_68bb38bf2c28832aa0a274024ead9e5b