### PR TITLE
feat: add admin screen and role-based access

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import AuthScreen from './components/AuthScreen';
 import LoadingScreen from './components/LoadingScreen';
 import ErrorBoundary from './components/ErrorBoundary';
 import RAGConfigurationPage from './components/RAGConfigurationPage';
+import AdminScreen from './components/AdminScreen';
 
 // Services
 import openaiService from './services/openaiService';
@@ -47,11 +48,14 @@ const AcceleraQA = () => {
   const [isInitialized, setIsInitialized] = useState(false);
   const [isServerAvailable, setIsServerAvailable] = useState(true);
   const [showRAGConfig, setShowRAGConfig] = useState(false);
+  const [showAdmin, setShowAdmin] = useState(false);
   const [ragEnabled, setRAGEnabled] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [lastSaveTime, setLastSaveTime] = useState(null);
   
   const messagesEndRef = useRef(null);
+
+  const isAdmin = user?.roles?.includes('admin');
 
   // Memoized values
   const allMessages = useMemo(() => 
@@ -458,6 +462,16 @@ const AcceleraQA = () => {
     setShowRAGConfig(false);
   }, []);
 
+  const handleShowAdmin = useCallback(() => {
+    if (isAdmin) {
+      setShowAdmin(true);
+    }
+  }, [isAdmin]);
+
+  const handleCloseAdmin = useCallback(() => {
+    setShowAdmin(false);
+  }, []);
+
   // Force refresh conversations from server
   const handleRefreshConversations = useCallback(async () => {
     if (!isServerAvailable || !user) return;
@@ -511,11 +525,16 @@ const AcceleraQA = () => {
     return <AuthScreen />;
   }
 
+  // Admin interface
+  if (showAdmin && isAdmin) {
+    return <AdminScreen onBack={handleCloseAdmin} />;
+  }
+
   // Main authenticated interface
   return (
     <ErrorBoundary>
       <div className="min-h-screen bg-gray-50">
-        <Header 
+        <Header
           user={user}
           showNotebook={showNotebook}
           setShowNotebook={setShowNotebook}
@@ -524,6 +543,8 @@ const AcceleraQA = () => {
           clearAllConversations={clearAllConversations}
           isServerAvailable={isServerAvailable}
           onShowRAGConfig={handleShowRAGConfig}
+          isAdmin={isAdmin}
+          onShowAdmin={handleShowAdmin}
           isSaving={isSaving}
           lastSaveTime={lastSaveTime}
           onRefresh={handleRefreshConversations}

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -1,0 +1,29 @@
+import React, { memo } from 'react';
+import { ArrowLeft } from 'lucide-react';
+
+const AdminScreen = memo(({ onBack }) => {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <header className="flex justify-between items-center mb-8">
+        <h1 className="text-2xl font-bold">Admin Panel</h1>
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="flex items-center space-x-2 px-4 py-2 bg-gray-800 text-white rounded hover:bg-gray-700 transition-colors"
+            aria-label="Back to app"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            <span>Back to App</span>
+          </button>
+        )}
+      </header>
+      <div className="space-y-4">
+        <p className="text-gray-600">Administrative controls and diagnostics go here.</p>
+      </div>
+    </div>
+  );
+});
+
+AdminScreen.displayName = 'AdminScreen';
+
+export default AdminScreen;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,6 @@
 // src/components/Header.js - Updated with save status and refresh functionality
 import React, { memo } from 'react';
-import { Download, Clock, MessageSquare, LogOut, User, AlertTriangle, FileSearch, RefreshCw, Cloud, CloudOff } from 'lucide-react';
+import { Download, Clock, MessageSquare, LogOut, User, AlertTriangle, FileSearch, RefreshCw, Cloud, CloudOff, Shield } from 'lucide-react';
 import { handleLogout } from '../services/authService';
 
 const Header = memo(({ 
@@ -14,7 +14,9 @@ const Header = memo(({
   onShowRAGConfig,
   isSaving = false,
   lastSaveTime = null,
-  onRefresh
+  onRefresh,
+  isAdmin = false,
+  onShowAdmin
 }) => {
   const handleToggleView = () => {
     setShowNotebook(!showNotebook);
@@ -39,6 +41,12 @@ const Header = memo(({
   const handleRAGConfigClick = () => {
     if (onShowRAGConfig) {
       onShowRAGConfig();
+    }
+  };
+
+  const handleAdminClick = () => {
+    if (onShowAdmin) {
+      onShowAdmin();
     }
   };
 
@@ -72,7 +80,7 @@ const Header = memo(({
 
   const formatLastSaveTime = (saveTime) => {
     if (!saveTime) return null;
-    
+
     const now = new Date();
     const diffMs = now - saveTime;
     const diffMins = Math.floor(diffMs / 60000);
@@ -85,6 +93,9 @@ const Header = memo(({
     
     return saveTime.toLocaleDateString();
   };
+
+  const displayName = user?.email || user?.name || 'User';
+  const roleLabel = user?.roles?.length ? user.roles.join(', ') : null;
 
   return (
     <header className="bg-gradient-to-r from-gray-900 via-gray-800 to-black text-white border-b border-gray-800 shadow">
@@ -106,7 +117,8 @@ const Header = memo(({
             <div className="flex items-center space-x-2 text-sm text-gray-300">
               <User className="h-4 w-4" />
               <span className="max-w-40 truncate">
-                {user?.email || user?.name || 'User'}
+                {displayName}
+                {roleLabel ? ` (${roleLabel})` : ''}
               </span>
             </div>
 
@@ -159,7 +171,19 @@ const Header = memo(({
               <FileSearch className="h-4 w-4" />
               <span className="hidden sm:block">RAG Config</span>
             </button>
-            
+
+            {isAdmin && (
+              <button
+                onClick={handleAdminClick}
+                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 rounded hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-label="Open admin panel"
+                title="Access administrative controls"
+              >
+                <Shield className="h-4 w-4" />
+                <span className="hidden sm:block">Admin</span>
+              </button>
+            )}
+
             {/* Clear Chat */}
             <button
               onClick={clearChat}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -78,8 +78,10 @@ class AuthService {
       if (!isAuth) {
         return null;
       }
-
-      return await this.auth0Client.getUser();
+      const user = await this.auth0Client.getUser();
+      const claims = await this.auth0Client.getIdTokenClaims();
+      const roles = claims?.['https://acceleraqa.com/roles'] || [];
+      return { ...user, roles };
     } catch (error) {
       console.error('Error getting user:', error);
       return null;


### PR DESCRIPTION
## Summary
- attach roles from ID token claims to user
- add AdminScreen component and navigation
- show Admin button for users with admin role
- display user roles next to the user name in the header

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb501dbc18832ab686e79a30c08e7b