### PR TITLE
feat: make Auth0 roles claim configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ REACT_APP_AUTH0_CLIENT_ID=your_client_id_here
 # Auth0 Configuration (Optional)
 # Only needed if you're using Auth0 APIs
 REACT_APP_AUTH0_AUDIENCE=your_api_audience_here
+REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 
 # Neon PostgreSQL Database Configuration (Required for persistent storage)
 # Get your connection string from: https://console.neon.tech/

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ REACT_APP_AUTH0_CLIENT_ID=your_client_id
 
 # Auth0 (Optional)
 REACT_APP_AUTH0_AUDIENCE=your_api_audience
+REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 ```
 
 ### 4. Auth0 Configuration
@@ -103,6 +104,8 @@ http://localhost:3000, https://your-app.netlify.app
 Allowed Web Origins:
 http://localhost:3000, https://your-app.netlify.app
 ```
+
+**Note:** `REACT_APP_AUTH0_ROLES_CLAIM` must match the custom claim added by your Auth0 Action/Rule.
 
 ### 5. Development
 ```bash

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -38,6 +38,7 @@ export const AUTH0_CONFIG = {
   DOMAIN: process.env.REACT_APP_AUTH0_DOMAIN,
   CLIENT_ID: process.env.REACT_APP_AUTH0_CLIENT_ID,
   AUDIENCE: process.env.REACT_APP_AUTH0_AUDIENCE,
+  ROLES_CLAIM: process.env.REACT_APP_AUTH0_ROLES_CLAIM,
   REDIRECT_URI: window.location.origin,
   LOGOUT_URI: window.location.origin,
   SCOPE: 'openid profile email'

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -80,7 +80,7 @@ class AuthService {
       }
       const user = await this.auth0Client.getUser();
       const claims = await this.auth0Client.getIdTokenClaims();
-      const roles = claims?.['https://acceleraqa.com/roles'] || [];
+      const roles = claims?.[AUTH0_CONFIG.ROLES_CLAIM] || [];
       return { ...user, roles };
     } catch (error) {
       console.error('Error getting user:', error);


### PR DESCRIPTION
## Summary
- expose `ROLES_CLAIM` in Auth0 config so the roles claim can be set via `REACT_APP_AUTH0_ROLES_CLAIM`
- use configurable claim when extracting roles in `authService`
- document `REACT_APP_AUTH0_ROLES_CLAIM` and update env example

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb56cda790832ab5ea9ac0b7904f9a