### PR TITLE
Include role claims in authService user data

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -80,6 +80,7 @@ class AuthService {
       }
       const user = await this.auth0Client.getUser();
       const claims = await this.auth0Client.getIdTokenClaims();
+      const roles = claims?.[AUTH0_CONFIG.ROLES_CLAIM] || [];
 
       return { ...user, roles };
     } catch (error) {

--- a/src/services/authService.test.js
+++ b/src/services/authService.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+
+describe('AuthService getUser', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns user data with roles when claim is present', async () => {
+    process.env.REACT_APP_AUTH0_ROLES_CLAIM = 'https://example.com/roles';
+    const authService = require('./authService').default;
+
+    authService.auth0Client = {
+      getUser: jest.fn().mockResolvedValue({ sub: 'user123', name: 'Test User' }),
+      getIdTokenClaims: jest.fn().mockResolvedValue({
+        'https://example.com/roles': ['admin', 'editor']
+      })
+    };
+    authService.isAuthenticated = jest.fn().mockResolvedValue(true);
+
+    const result = await authService.getUser();
+
+    expect(authService.auth0Client.getUser).toHaveBeenCalled();
+    expect(result).toEqual({
+      sub: 'user123',
+      name: 'Test User',
+      roles: ['admin', 'editor']
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- include roles from ID token claims in `getUser`
- test that `getUser` returns roles when claim exists

## Testing
- `npm test -- src/services/authService.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb631bd52c832a94de0f01c0d45534