### PR TITLE
refactor: centralize admin role detection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,12 +24,13 @@ import { initializeAuth } from './services/authService';
 
 // Utils
 import { exportNotebook } from './utils/exportUtils';
-import { 
-  getMessagesByDays, 
-  createMessage, 
+import {
+  getMessagesByDays,
+  createMessage,
   combineMessagesIntoConversations,
-  mergeCurrentAndStoredMessages 
+  mergeCurrentAndStoredMessages
 } from './utils/messageUtils';
+import { hasAdminRole } from './utils/auth';
 import { validateEnvironment, DEFAULT_RESOURCES } from './config/constants';
 
 const AcceleraQA = () => {
@@ -55,7 +56,7 @@ const AcceleraQA = () => {
   
   const messagesEndRef = useRef(null);
 
-  const isAdmin = user?.roles?.includes('admin');
+  const isAdmin = hasAdminRole(user);
 
   // Memoized values
   const allMessages = useMemo(() => 
@@ -463,10 +464,10 @@ const AcceleraQA = () => {
   }, []);
 
   const handleShowAdmin = useCallback(() => {
-    if (isAdmin) {
+    if (hasAdminRole(user)) {
       setShowAdmin(true);
     }
-  }, [isAdmin]);
+  }, [user]);
 
   const handleCloseAdmin = useCallback(() => {
     setShowAdmin(false);

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -28,6 +28,7 @@ import {
 import neonService from '../services/neonService';
 import ragService from '../services/ragService';
 import { getToken, getTokenInfo } from '../services/authService';
+import { hasAdminRole } from '../utils/auth';
 
 const AdminScreen = ({ user, onBack }) => {
   const [activeTab, setActiveTab] = useState('overview');
@@ -39,7 +40,7 @@ const AdminScreen = ({ user, onBack }) => {
   const [error, setError] = useState(null);
 
   // Check if user has admin role
-  const isAdmin = user?.roles?.includes('admin') || user?.roles?.includes('administrator');
+  const isAdmin = hasAdminRole(user);
 
   // Load admin data on component mount
   useEffect(() => {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,6 +2,7 @@
 import React, { memo, useMemo } from 'react';
 import { Download, Clock, MessageSquare, LogOut, User, AlertTriangle, FileSearch, RefreshCw, Cloud, CloudOff, Shield } from 'lucide-react';
 import { handleLogout } from '../services/authService';
+import { hasAdminRole } from '../utils/auth';
 
 const Header = memo(({ 
   user, 
@@ -18,23 +19,7 @@ const Header = memo(({
   onShowAdmin // Make sure this prop is being passed
 }) => {
   // Enhanced admin detection with debugging
-  const isAdmin = useMemo(() => {
-    if (!user || !user.roles) {
-      console.log('Header: No user or roles found');
-      return false;
-    }
-    
-    console.log('Header: Checking admin roles:', user.roles);
-    
-    // Check for various admin role formats
-    const adminRoles = ['admin', 'administrator', 'Admin', 'Administrator'];
-    const hasAdminRole = adminRoles.some(role => 
-      user.roles.includes(role)
-    );
-    
-    console.log('Header: Has admin role:', hasAdminRole);
-    return hasAdminRole;
-  }, [user]);
+  const isAdmin = useMemo(() => hasAdminRole(user), [user]);
 
   // Debug user object in development
   React.useEffect(() => {
@@ -44,8 +29,7 @@ const Header = memo(({
       console.log('User roles:', user.roles);
       console.log('User roles type:', typeof user.roles);
       console.log('Is array?:', Array.isArray(user.roles));
-      console.log('Roles includes admin?:', user.roles?.includes('admin'));
-      console.log('Roles includes administrator?:', user.roles?.includes('administrator'));
+      console.log('Has admin role:', hasAdminRole(user));
       console.log('isAdmin result:', isAdmin);
       console.log('=========================');
     }

--- a/src/services/authService.test.js
+++ b/src/services/authService.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { hasAdminRole } from '../utils/auth';
 
 describe('AuthService getUser', () => {
   beforeEach(() => {
@@ -25,5 +26,14 @@ describe('AuthService getUser', () => {
       name: 'Test User',
       roles: ['admin', 'editor']
     });
+  });
+});
+
+describe('hasAdminRole', () => {
+  it('handles mixed-case role names consistently', () => {
+    expect(hasAdminRole({ roles: ['Admin'] })).toBe(true);
+    expect(hasAdminRole({ roles: ['Administrator'] })).toBe(true);
+    expect(hasAdminRole({ roles: ['administrator'] })).toBe(true);
+    expect(hasAdminRole({ roles: ['editor'] })).toBe(false);
   });
 });

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,4 @@
+export function hasAdminRole(user) {
+  const roles = Array.isArray(user?.roles) ? user.roles : [];
+  return roles.some(r => ['admin', 'administrator'].includes(r.toLowerCase()));
+}


### PR DESCRIPTION
## Summary
- add shared `hasAdminRole` utility for case-insensitive admin detection
- use `hasAdminRole` across app, admin screen, and header components
- test `hasAdminRole` for mixed-case roles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6d7bf168832a9f2d7e62a31aaa56