### PR TITLE
Guard storage checks against missing navigator

### DIFF
--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -29,6 +29,34 @@ import neonService from '../services/neonService';
 import ragService from '../services/ragService';
 import { getToken, getTokenInfo } from '../services/authService';
 
+export const checkStorageHealth = async () => {
+  // Check browser storage capacity
+  try {
+    if (typeof navigator === 'undefined' || !navigator.storage) {
+      return {
+        status: 'unknown',
+        message: 'Storage info unavailable',
+        quota: null
+      };
+    }
+
+    const usage = await navigator.storage.estimate();
+    const usagePercent = (usage.usage / usage.quota * 100).toFixed(1);
+
+    return {
+      status: usage.usage / usage.quota < 0.8 ? 'healthy' : 'warning',
+      message: `Storage ${usagePercent}% used`,
+      quota: `${(usage.quota / 1024 / 1024).toFixed(0)}MB`
+    };
+  } catch (error) {
+    return {
+      status: 'unknown',
+      message: 'Storage info unavailable',
+      quota: null
+    };
+  }
+};
+
 const AdminScreen = ({ user, onBack }) => {
   const [activeTab, setActiveTab] = useState('overview');
   const [isLoading, setIsLoading] = useState(false);
@@ -219,26 +247,6 @@ const AdminScreen = ({ user, onBack }) => {
         status: 'error',
         message: error.message,
         expiresIn: null
-      };
-    }
-  };
-
-  const checkStorageHealth = async () => {
-    // Check browser storage capacity
-    try {
-      const usage = navigator.storage ? await navigator.storage.estimate() : null;
-      const usagePercent = usage ? (usage.usage / usage.quota * 100).toFixed(1) : 'Unknown';
-      
-      return {
-        status: usage && usage.usage / usage.quota < 0.8 ? 'healthy' : 'warning',
-        message: `Storage ${usagePercent}% used`,
-        quota: usage ? `${(usage.quota / 1024 / 1024).toFixed(0)}MB` : 'Unknown'
-      };
-    } catch (error) {
-      return {
-        status: 'unknown',
-        message: 'Storage info unavailable',
-        quota: null
       };
     }
   };

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -1,0 +1,17 @@
+import { checkStorageHealth } from './AdminScreen';
+
+describe('checkStorageHealth', () => {
+  it('returns unknown status when navigator storage is unavailable', async () => {
+    const originalNavigator = global.navigator;
+    // Simulate environment without navigator
+    // @ts-ignore - override for testing
+    global.navigator = undefined;
+
+    const result = await checkStorageHealth();
+    expect(result.status).toBe('unknown');
+
+    // Restore navigator
+    // @ts-ignore
+    global.navigator = originalNavigator;
+  });
+});


### PR DESCRIPTION
## Summary
- guard `checkStorageHealth` from undefined `navigator` before estimating storage
- export `checkStorageHealth` and return an `unknown` status when storage APIs aren't available
- add unit test verifying fallback when `navigator` is absent

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bb6d93618c832aaca072e8dd3f3bcb