### PR TITLE
Integrate RAG configuration into admin panel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,6 @@ import Sidebar from './components/Sidebar';
 import AuthScreen from './components/AuthScreen';
 import LoadingScreen from './components/LoadingScreen';
 import ErrorBoundary from './components/ErrorBoundary';
-import RAGConfigurationPage from './components/RAGConfigurationPage';
 import AdminScreen from './components/AdminScreen';
 
 // Services
@@ -48,7 +47,6 @@ const AcceleraQA = () => {
   const [error, setError] = useState(null);
   const [isInitialized, setIsInitialized] = useState(false);
   const [isServerAvailable, setIsServerAvailable] = useState(true);
-  const [showRAGConfig, setShowRAGConfig] = useState(false);
   const [showAdmin, setShowAdmin] = useState(false); // ADMIN STATE
   const [ragEnabled, setRAGEnabled] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -481,15 +479,6 @@ const AcceleraQA = () => {
     }
   }, [allMessages]);
 
-  // RAG config handlers
-  const handleShowRAGConfig = useCallback(() => {
-    setShowRAGConfig(true);
-  }, []);
-
-  const handleCloseRAGConfig = useCallback(() => {
-    setShowRAGConfig(false);
-  }, []);
-
   // Force refresh conversations from server
   const handleRefreshConversations = useCallback(async () => {
     if (!isServerAvailable || !user) return;
@@ -560,8 +549,6 @@ const AcceleraQA = () => {
           exportNotebook={handleExport}
           clearAllConversations={clearAllConversations}
           isServerAvailable={isServerAvailable}
-          onShowRAGConfig={handleShowRAGConfig}
-          isAdmin={isAdmin}
           onShowAdmin={handleShowAdmin} // FIXED: Properly passing the function
           isSaving={isSaving}
           lastSaveTime={lastSaveTime}
@@ -597,14 +584,6 @@ const AcceleraQA = () => {
             />
           </div>
         </div>
-
-        {/* RAG Configuration Modal */}
-        {showRAGConfig && (
-          <RAGConfigurationPage
-            user={user}
-            onClose={handleCloseRAGConfig}
-          />
-        )}
 
         {/* Save Status Indicator */}
         {isSaving && (

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -21,7 +21,8 @@ import {
   HardDrive,
   Zap,
   Bug,
-  Monitor
+  Monitor,
+  Search
 } from 'lucide-react';
 
 // Import services
@@ -29,6 +30,7 @@ import neonService from '../services/neonService';
 import ragService from '../services/ragService';
 import { getToken, getTokenInfo } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
+import RAGConfigurationPage from './RAGConfigurationPage';
 
 export const checkStorageHealth = async () => {
   // Check browser storage capacity
@@ -412,6 +414,7 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'users', label: 'Users & Auth', icon: Users },
               { id: 'database', label: 'Database', icon: Database },
               { id: 'rag', label: 'RAG System', icon: FileText },
+              { id: 'ragConfig', label: 'RAG Config', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
               { id: 'tools', label: 'Admin Tools', icon: Settings }
             ].map(tab => {
@@ -682,6 +685,13 @@ const AdminScreen = ({ user, onBack }) => {
                   )}
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* RAG Configuration Tab */}
+          {activeTab === 'ragConfig' && (
+            <div className="space-y-6">
+              <RAGConfigurationPage user={user} onClose={() => setActiveTab('overview')} />
             </div>
           )}
 

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -1,4 +1,34 @@
-import { checkStorageHealth } from './AdminScreen';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import AdminScreen, { checkStorageHealth } from './AdminScreen';
+
+jest.mock('./RAGConfigurationPage', () => () => <h2>RAG Configuration</h2>);
+
+jest.mock('../services/ragService', () => ({
+  __esModule: true,
+  default: {
+    getStats: jest.fn().mockResolvedValue({ totalDocuments: 0, totalChunks: 0 }),
+    runDiagnostics: jest.fn().mockResolvedValue({}),
+    testConnection: jest.fn().mockResolvedValue({ success: true }),
+    getDocuments: jest.fn().mockResolvedValue([]),
+    generateRAGResponse: jest.fn(),
+  }
+}));
+
+jest.mock('../services/neonService', () => ({
+  __esModule: true,
+  default: {
+    getConversationStats: jest.fn().mockResolvedValue({}),
+    isServiceAvailable: jest.fn().mockResolvedValue(true),
+  }
+}));
+
+jest.mock('../services/authService', () => ({
+  __esModule: true,
+  getToken: jest.fn().mockResolvedValue('token'),
+  getTokenInfo: jest.fn().mockReturnValue({}),
+}));
 
 describe('checkStorageHealth', () => {
   it('returns unknown status when navigator storage is unavailable', async () => {
@@ -13,5 +43,38 @@ describe('checkStorageHealth', () => {
     // Restore navigator
     // @ts-ignore
     global.navigator = originalNavigator;
+  });
+});
+
+describe('AdminScreen navigation', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('renders RAG Configuration page when RAG Config tab is selected', async () => {
+    const user = { roles: ['admin'] };
+
+    await act(async () => {
+      ReactDOM.render(<AdminScreen user={user} onBack={() => {}} />, container);
+    });
+
+    const ragButton = Array.from(container.querySelectorAll('button')).find(btn =>
+      btn.textContent && btn.textContent.includes('RAG Config')
+    );
+
+    await act(async () => {
+      ragButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const heading = container.querySelector('h2');
+    expect(heading && heading.textContent).toMatch(/RAG Configuration/i);
   });
 });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,6 @@
 // src/components/Header.js - UPDATED VERSION with cloud status and clear all button removed
 import React, { memo, useMemo } from 'react';
-import { Download, MessageSquare, LogOut, User, FileSearch, RefreshCw, Shield } from 'lucide-react';
+import { Download, MessageSquare, LogOut, User, RefreshCw, Shield } from 'lucide-react';
 import { handleLogout } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 
@@ -12,7 +12,6 @@ const Header = memo(({
   exportNotebook,
   clearAllConversations,
   isServerAvailable,
-  onShowRAGConfig,
   isSaving = false,
   lastSaveTime = null,
   onRefresh,
@@ -52,12 +51,6 @@ const Header = memo(({
       await handleLogout();
     } catch (error) {
       console.error('Logout failed:', error);
-    }
-  };
-
-  const handleRAGConfigClick = () => {
-    if (onShowRAGConfig) {
-      onShowRAGConfig();
     }
   };
 
@@ -132,17 +125,6 @@ const Header = memo(({
                 <span className="hidden sm:block">Refresh</span>
               </button>
             )}
-
-            {/* RAG Configuration Button */}
-            <button
-              onClick={handleRAGConfigClick}
-              className="flex items-center space-x-2 px-4 py-2 bg-purple-600 rounded hover:bg-purple-700 transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500"
-              aria-label="Configure RAG search"
-              title="Configure document search and RAG capabilities"
-            >
-              <FileSearch className="h-4 w-4" />
-              <span className="hidden sm:block">RAG Config</span>
-            </button>
 
             {/* Enhanced Admin Button */}
             {isAdmin && (


### PR DESCRIPTION
## Summary
- remove RAG configuration trigger from header and app modal
- add RAG Config tab to admin screen with embedded RAGConfigurationPage
- test admin navigation to RAG Config

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3d6b5d18832a9e0275ccd2354183