### PR TITLE
Open notebook in popup window and simplify sidebar

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,21 +1,19 @@
 // src/components/Header.js - UPDATED VERSION with cloud status and clear all button removed
 import React, { memo, useMemo } from 'react';
-import { Download, MessageSquare, LogOut, User, RefreshCw, Shield } from 'lucide-react';
+import { Download, LogOut, User, RefreshCw, Shield } from 'lucide-react';
 import { handleLogout } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 
 const Header = memo(({ 
-  user, 
-  showNotebook, 
-  setShowNotebook, 
-  clearChat, 
+  user,
+  clearChat,
   exportNotebook,
-  clearAllConversations,
   isServerAvailable,
   isSaving = false,
   lastSaveTime = null,
   onRefresh,
-  onShowAdmin
+  onShowAdmin,
+  openNotebookWindow
 }) => {
   // Enhanced admin detection with debugging
   const isAdmin = useMemo(() => hasAdminRole(user), [user]);
@@ -33,10 +31,6 @@ const Header = memo(({
       console.log('=========================');
     }
   }, [user, isAdmin]);
-
-  const handleToggleView = () => {
-    setShowNotebook(!showNotebook);
-  };
 
   const handleExportClick = () => {
     try {
@@ -166,26 +160,17 @@ const Header = memo(({
             >
               Clear
             </button>
-            
-            {/* Toggle Notebook/Chat View */}
+
+            {/* Open Notebook */}
             <button
-              onClick={handleToggleView}
+              onClick={openNotebookWindow}
               className="flex items-center space-x-2 px-4 py-2 bg-gray-800 rounded hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-600"
-              aria-label={showNotebook ? 'Switch to chat view' : 'Switch to notebook view'}
+              aria-label="Open notebook in new window"
             >
-              {showNotebook ? (
-                <>
-                  <MessageSquare className="h-4 w-4" />
-                  <span>Chat</span>
-                </>
-              ) : (
-                <>
-                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                  </svg>
-                  <span>Notebook</span>
-                </>
-              )}
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+              </svg>
+              <span>Open Notebook</span>
             </button>
             
             {/* Export */}

--- a/src/components/NotebookWindow.js
+++ b/src/components/NotebookWindow.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import NotebookView from './NotebookView';
+
+const NotebookWindow = ({
+  messages,
+  thirtyDayMessages,
+  selectedMessages,
+  setSelectedMessages,
+  generateStudyNotes,
+  isGeneratingNotes,
+  storedMessageCount = 0,
+  isServerAvailable = true
+}) => {
+  return (
+    <div className="p-6">
+      <NotebookView
+        messages={messages}
+        thirtyDayMessages={thirtyDayMessages}
+        selectedMessages={selectedMessages}
+        setSelectedMessages={setSelectedMessages}
+        generateStudyNotes={generateStudyNotes}
+        isGeneratingNotes={isGeneratingNotes}
+        storedMessageCount={storedMessageCount}
+        isServerAvailable={isServerAvailable}
+      />
+    </div>
+  );
+};
+
+export default NotebookWindow;
+

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,84 +1,10 @@
 import React, { memo } from 'react';
-import NotebookView from './NotebookView';
 import ResourcesView from './ResourcesView';
-import { Cloud, CloudOff } from 'lucide-react';
 
-const Sidebar = memo(({ 
-  showNotebook, 
-  messages, 
-  thirtyDayMessages, 
-  selectedMessages, 
-  setSelectedMessages, 
-  generateStudyNotes, 
-  isGeneratingNotes, 
-  currentResources,
-  storedMessageCount = 0,
-  isServerAvailable = true
-}) => {
-  
-  // Debug logging for sidebar
-  console.log('=== SIDEBAR DEBUG ===');
-  console.log('showNotebook:', showNotebook);
-  console.log('messages received:', messages?.length || 0);
-  console.log('thirtyDayMessages received:', thirtyDayMessages?.length || 0);
-  console.log('storedMessageCount:', storedMessageCount);
-  console.log('isServerAvailable:', isServerAvailable);
-  console.log('Will render:', showNotebook ? 'NotebookView' : 'ResourcesView');
-
+const Sidebar = memo(({ currentResources }) => {
   return (
     <div className="lg:col-span-1">
-      {/* Storage Status Banner */}
-      {showNotebook && (
-        <div className={`mb-4 p-3 rounded-lg border ${
-          isServerAvailable 
-            ? 'bg-green-50 border-green-200 text-green-800'
-            : 'bg-orange-50 border-orange-200 text-orange-800'
-        }`}>
-          <div className="flex items-center space-x-2">
-            {isServerAvailable ? (
-              <>
-                <Cloud className="h-4 w-4 text-green-600" />
-                <div className="flex-1">
-                  <div className="text-sm font-medium">Cloud Storage Active</div>
-                  <div className="text-xs text-green-600">
-                    {storedMessageCount > 0 
-                      ? `${storedMessageCount} messages saved to cloud`
-                      : 'Conversations automatically saved to Netlify Blob'
-                    }
-                  </div>
-                </div>
-              </>
-            ) : (
-              <>
-                <CloudOff className="h-4 w-4 text-orange-600" />
-                <div className="flex-1">
-                  <div className="text-sm font-medium">Session Only Mode</div>
-                  <div className="text-xs text-orange-600">
-                    Conversations will be lost on page refresh
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-      )}
-
-      {showNotebook ? (
-        <NotebookView
-          messages={messages}
-          thirtyDayMessages={thirtyDayMessages}
-          selectedMessages={selectedMessages}
-          setSelectedMessages={setSelectedMessages}
-          generateStudyNotes={generateStudyNotes}
-          isGeneratingNotes={isGeneratingNotes}
-          storedMessageCount={storedMessageCount}
-          isServerAvailable={isServerAvailable}
-        />
-      ) : (
-        <ResourcesView
-          currentResources={currentResources}
-        />
-      )}
+      <ResourcesView currentResources={currentResources} />
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- Remove `showNotebook` toggle logic and related props
- Add `NotebookWindow` component and `openNotebookWindow` function to render notebook in a new browser window
- Replace header toggle with “Open Notebook” button and simplify sidebar to always show resources

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc42fa8900832a9269ea64a7142b21