### PR TITLE
Move notebook export to overlay

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -502,6 +502,7 @@ const AcceleraQA = () => {
         isGeneratingNotes={isGeneratingNotes}
         storedMessageCount={storedMessages.length}
         isServerAvailable={isServerAvailable}
+        exportNotebook={handleExport}
         onClose={handleCloseNotebook}
       />
     );
@@ -524,7 +525,6 @@ const AcceleraQA = () => {
           <Header
             user={user}
             clearChat={clearChat}
-            exportNotebook={handleExport}
             onShowAdmin={handleShowAdmin} // FIXED: Properly passing the function
             isSaving={isSaving}
             lastSaveTime={lastSaveTime}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,13 +1,12 @@
 // src/components/Header.js - UPDATED VERSION with cloud status and clear all button removed
 import React, { memo, useMemo } from 'react';
-import { Download, LogOut, User, Shield } from 'lucide-react';
+import { LogOut, User, Shield } from 'lucide-react';
 import { handleLogout } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 
 const Header = memo(({ 
   user,
   clearChat,
-  exportNotebook,
   isSaving = false,
   lastSaveTime = null,
   onShowAdmin,
@@ -29,14 +28,6 @@ const Header = memo(({
       console.log('=========================');
     }
   }, [user, isAdmin]);
-
-  const handleExportClick = () => {
-    try {
-      exportNotebook();
-    } catch (error) {
-      console.error('Export failed:', error);
-    }
-  };
 
   const handleLogoutClick = async () => {
     try {
@@ -146,17 +137,6 @@ const Header = memo(({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
               </svg>
               <span>Open Notebook</span>
-            </button>
-            
-            {/* Export */}
-            <button
-              onClick={handleExportClick}
-              className="flex items-center space-x-2 px-4 py-2 bg-white text-black rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
-              aria-label="Export conversation history"
-              title="Export conversations to CSV file"
-            >
-              <Download className="h-4 w-4" />
-              <span>Export</span>
             </button>
             
             {/* Logout */}

--- a/src/components/NotebookOverlay.js
+++ b/src/components/NotebookOverlay.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X } from 'lucide-react';
+import { X, Download } from 'lucide-react';
 import NotebookView from './NotebookView';
 
 const NotebookOverlay = ({
@@ -11,20 +11,40 @@ const NotebookOverlay = ({
   isGeneratingNotes,
   storedMessageCount,
   isServerAvailable,
+  exportNotebook,
   onClose
 }) => {
+  const handleExportClick = () => {
+    try {
+      exportNotebook();
+    } catch (error) {
+      console.error('Export failed:', error);
+    }
+  };
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg shadow-xl max-w-6xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <h2 className="text-xl font-semibold text-gray-900">Notebook</h2>
-          <button
-            onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-            aria-label="Close notebook"
-          >
-            <X className="h-5 w-5 text-gray-500" />
-          </button>
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={handleExportClick}
+              className="flex items-center space-x-2 px-4 py-2 bg-white text-black rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
+              aria-label="Export notebook"
+              title="Export conversations to CSV file"
+            >
+              <Download className="h-4 w-4" />
+              <span>Export</span>
+            </button>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              aria-label="Close notebook"
+            >
+              <X className="h-5 w-5 text-gray-500" />
+            </button>
+          </div>
         </div>
         <div className="p-6 overflow-y-auto flex-1">
           <NotebookView


### PR DESCRIPTION
## Summary
- drop export handling from the header
- pass export handler into notebook overlay
- add export button inside notebook overlay

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc4ccc1d48832aa1a0f0669dbcd61b