### PR TITLE
refactor: move clear chat control

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -524,7 +524,6 @@ const AcceleraQA = () => {
       <div className="min-h-screen bg-gray-50">
           <Header
             user={user}
-            clearChat={clearChat}
             onShowAdmin={handleShowAdmin} // FIXED: Properly passing the function
             isSaving={isSaving}
             lastSaveTime={lastSaveTime}
@@ -543,6 +542,7 @@ const AcceleraQA = () => {
               messagesEndRef={messagesEndRef}
               ragEnabled={ragEnabled}
               setRAGEnabled={setRAGEnabled}
+              clearChat={clearChat}
               isSaving={isSaving}
             />
             

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -4,15 +4,16 @@ import { exportToWord } from '../utils/exportUtils';
 import { sanitizeMessageContent } from '../utils/messageUtils';
 
 const ChatArea = memo(({ 
-  messages, 
-  inputMessage, 
-  setInputMessage, 
-  isLoading, 
-  handleSendMessage, 
-  handleKeyPress, 
+  messages,
+  inputMessage,
+  setInputMessage,
+  isLoading,
+  handleSendMessage,
+  handleKeyPress,
   messagesEndRef,
   ragEnabled,
   setRAGEnabled,
+  clearChat,
   isSaving = false
 }) => {
   const handleInputChange = (e) => {
@@ -160,14 +161,14 @@ const ChatArea = memo(({
 
       {/* Input Area */}
       <div className="border-t border-gray-700 bg-gray-900 p-8 flex-shrink-0">
-        {/* RAG Toggle and Save Status */}
+        {/* RAG Toggle, Clear Chat, and Save Status */}
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <button
               onClick={toggleRAG}
               className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-colors ${
-                ragEnabled 
-                  ? 'bg-blue-600 text-white hover:bg-blue-700' 
+                ragEnabled
+                  ? 'bg-blue-600 text-white hover:bg-blue-700'
                   : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
               }`}
               aria-label={ragEnabled ? 'Disable RAG search' : 'Enable RAG search'}
@@ -177,8 +178,18 @@ const ChatArea = memo(({
                 RAG Search {ragEnabled ? 'ON' : 'OFF'}
               </span>
             </button>
+
+            <button
+              onClick={clearChat}
+              className="px-4 py-2 bg-gray-700 text-gray-300 rounded-lg hover:bg-gray-600 transition-colors text-sm font-medium"
+              aria-label="Clear current chat"
+              title="Clear current conversation"
+            >
+              Clear Chat
+            </button>
+
             <div className="text-xs text-gray-400">
-              {ragEnabled 
+              {ragEnabled
                 ? 'AI will search your uploaded documents for context'
                 : 'AI will use general pharmaceutical knowledge only'
               }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,7 +6,6 @@ import { hasAdminRole } from '../utils/auth';
 
 const Header = memo(({ 
   user,
-  clearChat,
   isSaving = false,
   lastSaveTime = null,
   onShowAdmin,
@@ -116,16 +115,6 @@ const Header = memo(({
                 No Admin Role
               </div>
             )}
-
-            {/* Clear Chat */}
-            <button
-              onClick={clearChat}
-              className="px-4 py-2 text-gray-300 hover:text-white transition-colors text-sm font-medium"
-              aria-label="Clear current chat"
-              title="Clear current conversation (saves to cloud first)"
-            >
-              Clear
-            </button>
 
             {/* Open Notebook */}
             <button


### PR DESCRIPTION
## Summary
- remove clear chat button from Header
- pass clearChat handler to ChatArea and add clear chat button alongside RAG toggle
- update App to wire clearChat to ChatArea instead of Header

## Testing
- `npm test -- --watchAll=false` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc61bedd48832ab8498e395853aa51