### PR TITLE
Implement three-column layout with learning panel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import Header from './components/Header';
 import ChatArea from './components/ChatArea';
 import Sidebar from './components/Sidebar';
+import LearningPanel from './components/LearningPanel';
 import NotebookOverlay from './components/NotebookOverlay';
 import AuthScreen from './components/AuthScreen';
 import LoadingScreen from './components/LoadingScreen';
@@ -531,7 +532,8 @@ const AcceleraQA = () => {
           />
 
         <div className="max-w-7xl mx-auto px-6 py-8 h-[calc(100vh-64px)]">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 h-full min-h-0">
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 h-full min-h-0">
+            <Sidebar currentResources={currentResources} />
             <ChatArea
               messages={messages}
               inputMessage={inputMessage}
@@ -545,10 +547,7 @@ const AcceleraQA = () => {
               clearChat={clearChat}
               isSaving={isSaving}
             />
-            
-              <Sidebar
-                currentResources={currentResources}
-              />
+            <LearningPanel />
           </div>
         </div>
 

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -38,7 +38,7 @@ const ChatArea = memo(({
   };
 
   return (
-    <div className="lg:col-span-2 rounded-lg border border-gray-200 p-6 h-full shadow-sm bg-gray-900/60 backdrop-blur-sm flex flex-col text-gray-100">
+    <div className="lg:col-span-6 rounded-lg border border-gray-200 p-6 h-full shadow-sm bg-gray-900/60 backdrop-blur-sm flex flex-col text-gray-100">
       {/* Chat Messages */}
       <div className="flex-1 h-full overflow-y-auto p-8 space-y-6 min-h-0 bg-white text-gray-900" style={{ scrollBehavior: 'smooth' }}>
         {messages.length === 0 ? (

--- a/src/components/LearningPanel.js
+++ b/src/components/LearningPanel.js
@@ -1,0 +1,16 @@
+import React, { memo } from 'react';
+
+const LearningPanel = memo(() => {
+  return (
+    <div className="lg:col-span-3">
+      <div className="rounded-lg border border-gray-200 p-6 h-full shadow-sm bg-white">
+        <h2 className="text-lg font-semibold mb-4 text-gray-900">Learning Panel</h2>
+        <p className="text-gray-600">Select a topic to start learning.</p>
+      </div>
+    </div>
+  );
+});
+
+LearningPanel.displayName = 'LearningPanel';
+
+export default LearningPanel;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -3,7 +3,7 @@ import ResourcesView from './ResourcesView';
 
 const Sidebar = memo(({ currentResources }) => {
   return (
-    <div className="lg:col-span-1">
+    <div className="lg:col-span-3">
       <ResourcesView currentResources={currentResources} />
     </div>
   );


### PR DESCRIPTION
## Summary
- restructure app grid to include sidebar, chat area, and learning panel under the header
- adjust sidebar and chat area column spans for responsive 12-column grid
- add placeholder LearningPanel component

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc67441aec832abf5475c8fa1ab9e5