### PR TITLE
Adopt light chat theme and add source banner

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -38,9 +38,12 @@ const ChatArea = memo(({
   };
 
   return (
-    <div className="lg:col-span-2 rounded-lg border border-gray-200 p-6 h-full shadow-sm bg-gray-900/60 backdrop-blur-sm flex flex-col text-gray-100">
+    <div className="lg:col-span-2 rounded-lg border border-gray-200 p-6 h-full shadow-sm bg-white flex flex-col text-gray-900">
       {/* Chat Messages */}
-      <div className="flex-1 h-full overflow-y-auto p-8 space-y-6 min-h-0 bg-white text-gray-900" style={{ scrollBehavior: 'smooth' }}>
+      <div className="flex-1 h-full overflow-y-auto p-8 space-y-6 min-h-0 bg-gray-50 text-gray-900" style={{ scrollBehavior: 'smooth' }}>
+        <div className="px-4 py-2 text-sm text-purple-700 bg-purple-50 border border-purple-100 rounded">
+          Answers are grouped in approved sources only.
+        </div>
         {messages.length === 0 ? (
           <div className="text-center py-16">
             <div className="w-16 h-16 bg-gradient-to-r from-primary to-primary-light rounded-lg mx-auto mb-6 flex items-center justify-center">
@@ -61,12 +64,12 @@ const ChatArea = memo(({
         ) : (
           messages.map((message) => (
             <div key={message.id} className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}>
-              <div className={`max-w-3xl px-6 py-4 rounded-lg ${
+              <div className={`max-w-3xl px-6 py-4 rounded-lg shadow-sm ${
                 message.type === 'user'
-                  ? 'bg-primary text-white'
+                  ? 'bg-purple-100 border border-purple-200 text-purple-900'
                   : message.isStudyNotes
-                    ? 'bg-gradient-to-r from-primary-dark to-primary border border-primary text-white'
-                    : 'bg-gray-800 border border-gray-700 text-gray-100'
+                    ? 'bg-gradient-to-r from-purple-100 to-purple-200 border border-purple-200 text-purple-900'
+                    : 'bg-gray-100 border border-gray-200 text-gray-900'
               }`}>
                 <div 
                   className="whitespace-pre-wrap text-base leading-relaxed"
@@ -79,18 +82,18 @@ const ChatArea = memo(({
                 
                 {/* Show sources if RAG was used */}
                 {message.sources && message.sources.length > 0 && (
-                  <div className="mt-3 pt-3 border-t border-gray-600">
-                    <div className="text-sm text-gray-300 mb-2">
+                  <div className="mt-3 pt-3 border-t border-gray-200">
+                    <div className="text-sm text-gray-600 mb-2">
                       📄 Sources from your documents:
                     </div>
                     <div className="space-y-1">
                       {message.sources.slice(0, 3).map((source, index) => (
-                        <div key={index} className="text-xs text-gray-400">
+                        <div key={index} className="text-xs text-gray-500">
                           • {source.filename} ({(source.similarity * 100).toFixed(1)}% match)
                         </div>
                       ))}
                       {message.sources.length > 3 && (
-                        <div className="text-xs text-gray-400">
+                        <div className="text-xs text-gray-500">
                           +{message.sources.length - 3} more sources
                         </div>
                       )}
@@ -101,25 +104,25 @@ const ChatArea = memo(({
                 {message.type === 'ai' && (
                   <div className={`flex items-center justify-between mt-3 pt-3 border-t ${
                     message.isStudyNotes
-                      ? 'border-primary text-gray-300'
-                      : 'border-gray-700 text-gray-400'
+                      ? 'border-purple-200 text-gray-500'
+                      : 'border-gray-200 text-gray-500'
                   }`}>
                     <div className="flex items-center space-x-3">
-                      <time className="text-xs" dateTime={message.timestamp}>
+                      <time className="text-xs text-gray-500" dateTime={message.timestamp}>
                         {new Date(message.timestamp).toLocaleString()}
                       </time>
                       {message.isStudyNotes && (
-                        <span className="text-xs text-primary-light font-medium">
+                        <span className="text-xs bg-purple-100 text-purple-700 px-2 py-0.5 rounded">
                           📚 Study Notes
                         </span>
                       )}
                       {message.sources && message.sources.length > 0 && (
-                        <span className="text-xs text-blue-400 font-medium">
+                        <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
                           🔍 RAG Enhanced
                         </span>
                       )}
                       {message.isStored && (
-                        <span className="text-xs text-green-400 font-medium flex items-center space-x-1">
+                        <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded flex items-center space-x-1">
                           <Cloud className="h-3 w-3" />
                           <span>Saved</span>
                         </span>
@@ -129,7 +132,7 @@ const ChatArea = memo(({
                     {message.isStudyNotes && (
                       <button
                         onClick={() => handleExportStudyNotes(message)}
-                        className="ml-3 px-3 py-1 bg-primary text-white text-xs rounded hover:bg-primary-dark transition-colors flex items-center space-x-1 focus:outline-none focus:ring-2 focus:ring-primary-light"
+                        className="ml-3 px-3 py-1 bg-purple-500 text-white text-xs rounded hover:bg-purple-600 transition-colors flex items-center space-x-1 focus:outline-none focus:ring-2 focus:ring-purple-300"
                         aria-label="Export study notes to Word document"
                       >
                         <FileText className="h-3 w-3" />
@@ -145,10 +148,10 @@ const ChatArea = memo(({
 
         {isLoading && (
           <div className="flex justify-start">
-            <div className="bg-gray-800 border border-gray-700 px-6 py-4 rounded-lg">
+            <div className="bg-gray-100 border border-gray-200 px-6 py-4 rounded-lg shadow-sm">
               <div className="flex items-center space-x-3">
                 <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary-light" />
-                <span className="text-gray-300">
+                <span className="text-gray-600">
                   {ragEnabled ? 'Searching documents and analyzing...' : 'Analyzing your question...'}
                 </span>
               </div>
@@ -160,7 +163,7 @@ const ChatArea = memo(({
       </div>
 
       {/* Input Area */}
-      <div className="border-t border-gray-700 bg-gray-900 p-8 flex-shrink-0">
+      <div className="border-t border-gray-200 bg-white p-8 flex-shrink-0">
         {/* RAG Toggle, Clear Chat, and Save Status */}
         <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center space-x-3">
@@ -169,7 +172,7 @@ const ChatArea = memo(({
               className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-colors ${
                 ragEnabled
                   ? 'bg-blue-600 text-white hover:bg-blue-700'
-                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
               }`}
               aria-label={ragEnabled ? 'Disable RAG search' : 'Enable RAG search'}
             >
@@ -181,14 +184,14 @@ const ChatArea = memo(({
 
             <button
               onClick={clearChat}
-              className="px-4 py-2 bg-gray-700 text-gray-300 rounded-lg hover:bg-gray-600 transition-colors text-sm font-medium"
+              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors text-sm font-medium"
               aria-label="Clear current chat"
               title="Clear current conversation"
             >
               Clear Chat
             </button>
 
-            <div className="text-xs text-gray-400">
+            <div className="text-xs text-gray-500">
               {ragEnabled
                 ? 'AI will search your uploaded documents for context'
                 : 'AI will use general pharmaceutical knowledge only'
@@ -198,8 +201,8 @@ const ChatArea = memo(({
 
           {/* Save Status Indicator */}
           {isSaving && (
-            <div className="flex items-center space-x-2 text-blue-400 text-sm">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-400" />
+            <div className="flex items-center space-x-2 text-blue-600 text-sm">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600" />
               <span>Auto-saving to cloud...</span>
             </div>
           )}
@@ -211,18 +214,18 @@ const ChatArea = memo(({
               value={inputMessage}
               onChange={handleInputChange}
               onKeyDown={handleKeyPress}
-              placeholder={ragEnabled 
+              placeholder={ragEnabled
                 ? "Ask about your documents or pharmaceutical topics..."
                 : "Ask about GMP, validation, CAPA, regulations..."
               }
-              className="w-full px-4 py-4 bg-gray-800 border border-gray-700 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent text-base text-gray-100 placeholder-gray-500 resize-none min-h-[60px] max-h-32"
+              className="w-full px-4 py-4 bg-gray-50 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent text-base text-gray-900 placeholder-gray-500 resize-none min-h-[60px] max-h-32"
               disabled={isLoading || isSaving}
               rows={1}
               aria-label="Enter your pharmaceutical quality question"
             />
             
             {inputMessage.length > 500 && (
-              <div className="absolute bottom-2 right-2 text-xs text-gray-400">
+              <div className="absolute bottom-2 right-2 text-xs text-gray-500">
                 {inputMessage.length}/2000
               </div>
             )}
@@ -243,21 +246,21 @@ const ChatArea = memo(({
           <div className="mt-4 flex flex-wrap gap-2">
             <button
               onClick={() => setInputMessage("What are the key requirements for GMP compliance?")}
-              className="text-sm px-3 py-1 bg-gray-800 border border-gray-700 text-gray-200 rounded-full hover:bg-gray-700 transition-colors"
+              className="text-sm px-3 py-1 bg-gray-100 border border-gray-200 text-gray-700 rounded-full hover:bg-gray-200 transition-colors"
               disabled={isLoading || isSaving}
             >
               GMP compliance requirements
             </button>
             <button
               onClick={() => setInputMessage("How do I develop a validation master plan?")}
-              className="text-sm px-3 py-1 bg-gray-800 border border-gray-700 text-gray-200 rounded-full hover:bg-gray-700 transition-colors"
+              className="text-sm px-3 py-1 bg-gray-100 border border-gray-200 text-gray-700 rounded-full hover:bg-gray-200 transition-colors"
               disabled={isLoading || isSaving}
             >
               Validation master plan
             </button>
             <button
               onClick={() => setInputMessage("What is the CAPA process?")}
-              className="text-sm px-3 py-1 bg-gray-800 border border-gray-700 text-gray-200 rounded-full hover:bg-gray-700 transition-colors"
+              className="text-sm px-3 py-1 bg-gray-100 border border-gray-200 text-gray-700 rounded-full hover:bg-gray-200 transition-colors"
               disabled={isLoading || isSaving}
             >
               CAPA process
@@ -265,7 +268,7 @@ const ChatArea = memo(({
             {ragEnabled && (
               <button
                 onClick={() => setInputMessage("Search my documents for quality procedures")}
-                className="text-sm px-3 py-1 bg-blue-800 border border-blue-700 text-blue-200 rounded-full hover:bg-blue-700 transition-colors"
+                className="text-sm px-3 py-1 bg-blue-100 border border-blue-200 text-blue-700 rounded-full hover:bg-blue-200 transition-colors"
                 disabled={isLoading || isSaving}
               >
                 Search my documents


### PR DESCRIPTION
## Summary
- lighten chat area with soft gray background and add introductory banner on source grouping
- restyle message bubbles with subtle gray/purple tones and shadows
- refine timestamp display and badges for sources, study notes, and saved messages

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc673b8558832a825e488d4ac64e45