### PR TITLE
feat: lighten global theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,8 +9,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: radial-gradient(circle at 25% 25%, #1e293b, #0f172a 70%);
-  color: #f1f5f9;
+  background-color: #f8fafc;
+  color: #0f172a;
 }
 
 code {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,8 @@ module.exports = {
           dark: '#312e81',
           light: '#6366f1',
         },
+        background: '#f8fafc',
+        accent: '#a855f7',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add light background and accent purple hues to Tailwind theme
- switch global styles to light background and dark text

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc67378834832a97846cd6735aac70