### PR TITLE
Add learning panel to display training modules

### DIFF
--- a/src/components/LearningPanel.js
+++ b/src/components/LearningPanel.js
@@ -1,0 +1,63 @@
+import React, { memo, useState } from 'react';
+import { PlayCircle, ChevronRight } from 'lucide-react';
+
+const mockModules = [
+  { id: 1, title: 'GMP Basics', duration: '15m', progress: 0.3 },
+  { id: 2, title: 'Deviation Handling', duration: '20m', progress: 0.7 },
+  { id: 3, title: 'CAPA Fundamentals', duration: '10m', progress: 0.1 },
+];
+
+const LearningPanel = memo(({ modules = mockModules }) => {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 h-full shadow-sm flex flex-col">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-bold text-gray-900">Training Modules</h3>
+        <PlayCircle className="h-6 w-6 text-gray-400" />
+      </div>
+      <div className="space-y-4 overflow-y-auto">
+        {modules.map(module => (
+          <ModuleCard key={module.id} module={module} />
+        ))}
+        {modules.length === 0 && (
+          <p className="text-sm text-gray-500">No modules available.</p>
+        )}
+      </div>
+    </div>
+  );
+});
+
+const ModuleCard = memo(({ module }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <div
+      className="group border border-gray-200 rounded-lg hover:border-gray-400 hover:shadow-sm transition-all duration-300 cursor-pointer"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="p-4">
+        <div className="flex items-start justify-between mb-2">
+          <h4 className="font-semibold text-gray-900 group-hover:text-black">{module.title}</h4>
+          <span className="text-sm text-gray-500">{module.duration}</span>
+        </div>
+        <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-blue-500 rounded-full"
+            style={{ width: `${Math.round(module.progress * 100)}%` }}
+          ></div>
+        </div>
+        <div className="flex items-center justify-between text-xs text-gray-500 mt-2">
+          <span>{Math.round(module.progress * 100)}% complete</span>
+          <ChevronRight
+            className={`h-4 w-4 text-gray-400 group-hover:text-black transition-all ml-2 flex-shrink-0 ${isHovered ? 'translate-x-1' : ''}`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ModuleCard.displayName = 'ModuleCard';
+LearningPanel.displayName = 'LearningPanel';
+
+export default LearningPanel;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,10 +1,16 @@
 import React, { memo } from 'react';
 import ResourcesView from './ResourcesView';
+import LearningPanel from './LearningPanel';
 
 const Sidebar = memo(({ currentResources }) => {
   return (
-    <div className="lg:col-span-1">
-      <ResourcesView currentResources={currentResources} />
+    <div className="lg:col-span-1 flex flex-col gap-8 h-full">
+      <div className="flex-1 min-h-0">
+        <ResourcesView currentResources={currentResources} />
+      </div>
+      <div className="flex-1 min-h-0">
+        <LearningPanel />
+      </div>
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- create `LearningPanel` component showing training modules with progress and durations
- integrate new panel into sidebar alongside `ResourcesView`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc673f3cc0832ab5fbcc4a2ef4be46