### PR TITLE
fix: clean up LearningPanel component

### DIFF
--- a/src/components/LearningPanel.js
+++ b/src/components/LearningPanel.js
@@ -1,4 +1,3 @@
-
 import React, { memo, useState } from 'react';
 import { PlayCircle, ChevronRight } from 'lucide-react';
 
@@ -53,24 +52,12 @@ const ModuleCard = memo(({ module }) => {
             className={`h-4 w-4 text-gray-400 group-hover:text-black transition-all ml-2 flex-shrink-0 ${isHovered ? 'translate-x-1' : ''}`}
           />
         </div>
-
-import React, { memo } from 'react';
-
-const LearningPanel = memo(() => {
-  return (
-    <div className="lg:col-span-3">
-      <div className="rounded-lg border border-gray-200 p-6 h-full shadow-sm bg-white">
-        <h2 className="text-lg font-semibold mb-4 text-gray-900">Learning Panel</h2>
-        <p className="text-gray-600">Select a topic to start learning.</p>
-
       </div>
     </div>
   );
 });
 
-
 ModuleCard.displayName = 'ModuleCard';
-
 LearningPanel.displayName = 'LearningPanel';
 
 export default LearningPanel;


### PR DESCRIPTION
## Summary
- restore LearningPanel component structure
- remove duplicate imports and component definitions causing syntax error

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc717a0c4c832aa36151b911fbe298