### PR TITLE
feat: add configurable width for sidebar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -533,7 +533,7 @@ const AcceleraQA = () => {
 
         <div className="max-w-7xl mx-auto px-6 py-8 h-[calc(100vh-64px)]">
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 h-full min-h-0">
-            <Sidebar currentResources={currentResources} />
+            <Sidebar currentResources={currentResources} className="lg:col-span-3" />
             <ChatArea
               messages={messages}
               inputMessage={inputMessage}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -13,11 +13,11 @@ const navItems = [
   { name: 'SOPs', href: '/sops', icon: ClipboardList }
 ];
 
-const Sidebar = memo(({ currentResources = [] }) => {
+const Sidebar = memo(({ currentResources = [], className = 'lg:col-span-3' }) => {
   const currentPath = typeof window !== 'undefined' ? window.location.pathname : '';
 
   return (
-    <div>
+    <div className={className}>
       {/* Sidebar content goes here */}
     </div>
   );


### PR DESCRIPTION
## Summary
- allow Sidebar to receive a `className` prop with a default width of `lg:col-span-3`
- pass width class from `App.js` so sidebar column size can be configured

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc792ba590832a93e65b9ae623ad7b