### PR TITLE
Initialize Auth0 state on mount and reset auth on logout

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -9,7 +9,8 @@ const Header = memo(({
   isSaving = false,
   lastSaveTime = null,
   onShowAdmin,
-  onOpenNotebook
+  onOpenNotebook,
+  onLogout
 }) => {
   // Enhanced admin detection with debugging
   const isAdmin = useMemo(() => hasAdminRole(user), [user]);
@@ -31,6 +32,9 @@ const Header = memo(({
   const handleLogoutClick = async () => {
     try {
       await handleLogout();
+      if (onLogout) {
+        onLogout();
+      }
     } catch (error) {
       console.error('Logout failed:', error);
     }


### PR DESCRIPTION
## Summary
- replace demo authentication effect with real Auth0 initialization
- update logout flow to reset authentication state

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc9095c140832ab781d4fc499f66b5