### PR TITLE
Use onBack prop for AdminScreen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -159,7 +159,7 @@ function App() {
       ) : showRAGConfig ? (
         <RAGConfigurationPage onClose={handleCloseRAGConfig} user={user} />
       ) : showAdmin ? (
-        <AdminScreen onClose={handleCloseAdmin} user={user} />
+        <AdminScreen onBack={handleCloseAdmin} user={user} />
       ) : (
         <>
         <div className="min-h-screen bg-gray-50">

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -77,4 +77,23 @@ describe('AdminScreen navigation', () => {
     const heading = container.querySelector('h2');
     expect(heading && heading.textContent).toMatch(/RAG Configuration/i);
   });
+
+  it('calls onBack when back button is clicked', async () => {
+    const user = { roles: ['admin'] };
+    const onBack = jest.fn();
+
+    await act(async () => {
+      ReactDOM.render(<AdminScreen user={user} onBack={onBack} />, container);
+    });
+
+    const backButton = Array.from(container.querySelectorAll('button')).find(btn =>
+      btn.textContent && btn.textContent.includes('Back to App')
+    );
+
+    await act(async () => {
+      backButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onBack).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- use `onBack` prop when rendering `AdminScreen`
- add test ensuring AdminScreen's back button triggers handler

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc97c4cf3c832a84c579b55b2444ec