### PR TITLE
feat: enable sorting conversations in notebook

### DIFF
--- a/src/components/NotebookOverlay.js
+++ b/src/components/NotebookOverlay.js
@@ -15,6 +15,7 @@ const NotebookOverlay = ({
   onClose
 }) => {
   const [searchTerm, setSearchTerm] = useState('');
+  const [sortOrder, setSortOrder] = useState('desc');
 
   const handleExportClick = () => {
     try {
@@ -29,35 +30,44 @@ const NotebookOverlay = ({
       <div className="bg-white rounded-lg shadow-xl max-w-6xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <h2 className="text-xl font-semibold text-gray-900">Notebook</h2>
-          <div className="flex items-center space-x-2">
-            <div className="relative">
-              <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder="Search..."
-                className="pl-9 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-500 text-sm w-48"
-                aria-label="Search notebook"
-              />
+            <div className="flex items-center space-x-2">
+              <div className="relative">
+                <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                <input
+                  type="text"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  placeholder="Search..."
+                  className="pl-9 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-500 text-sm w-48"
+                  aria-label="Search notebook"
+                />
+              </div>
+              <select
+                value={sortOrder}
+                onChange={(e) => setSortOrder(e.target.value)}
+                className="text-sm border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-gray-500"
+                aria-label="Sort conversations"
+              >
+                <option value="desc">Newest first</option>
+                <option value="asc">Oldest first</option>
+              </select>
+              <button
+                onClick={handleExportClick}
+                className="flex items-center space-x-2 px-4 py-2 bg-white text-black rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
+                aria-label="Export notebook"
+                title="Export conversations to CSV file"
+              >
+                <Download className="h-4 w-4" />
+                <span>Export</span>
+              </button>
+              <button
+                onClick={onClose}
+                className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+                aria-label="Close notebook"
+              >
+                <X className="h-5 w-5 text-gray-500" />
+              </button>
             </div>
-            <button
-              onClick={handleExportClick}
-              className="flex items-center space-x-2 px-4 py-2 bg-white text-black rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300"
-              aria-label="Export notebook"
-              title="Export conversations to CSV file"
-            >
-              <Download className="h-4 w-4" />
-              <span>Export</span>
-            </button>
-            <button
-              onClick={onClose}
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-              aria-label="Close notebook"
-            >
-              <X className="h-5 w-5 text-gray-500" />
-            </button>
-          </div>
         </div>
         <div className="p-6 overflow-y-auto flex-1">
           <NotebookView
@@ -70,6 +80,7 @@ const NotebookOverlay = ({
             storedMessageCount={storedMessageCount}
             isServerAvailable={isServerAvailable}
             searchTerm={searchTerm}
+            sortOrder={sortOrder}
           />
         </div>
       </div>

--- a/src/components/NotebookView.js
+++ b/src/components/NotebookView.js
@@ -11,7 +11,8 @@ const NotebookView = memo(({
   isGeneratingNotes,
   storedMessageCount = 0,
   isServerAvailable = true,
-  searchTerm = ''
+  searchTerm = '',
+  sortOrder = 'desc'
 }) => {
   // Use ALL available messages - try thirtyDayMessages first, fallback to messages
   const availableMessages = thirtyDayMessages.length > 0 ? thirtyDayMessages : messages;
@@ -22,15 +23,26 @@ const NotebookView = memo(({
     [availableMessages]
   );
 
+  // Sort conversations
+  const sortedConversations = useMemo(() => {
+    const convs = [...baseConversations];
+    convs.sort((a, b) =>
+      sortOrder === 'asc'
+        ? new Date(a.timestamp) - new Date(b.timestamp)
+        : new Date(b.timestamp) - new Date(a.timestamp)
+    );
+    return convs;
+  }, [baseConversations, sortOrder]);
+
   // Filter conversations by search term
   const conversations = useMemo(() => {
-    if (!searchTerm.trim()) return baseConversations;
+    if (!searchTerm.trim()) return sortedConversations;
     const lower = searchTerm.toLowerCase();
-    return baseConversations.filter(conv =>
+    return sortedConversations.filter(conv =>
       (conv.userContent && conv.userContent.toLowerCase().includes(lower)) ||
       (conv.aiContent && conv.aiContent.toLowerCase().includes(lower))
     );
-  }, [baseConversations, searchTerm]);
+  }, [sortedConversations, searchTerm]);
 
   const selectAllConversations = () => {
     const allIds = new Set(conversations.map(conv => conv.id));


### PR DESCRIPTION
## Summary
- add sort dropdown in notebook overlay to choose newest or oldest order
- sort conversations in NotebookView based on selected order

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bd91151cb8832a81d35d381d5380d6