### PR TITLE
Fix notebook not showing chat responses

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -172,6 +172,7 @@ function App() {
     const userMessage = {
       id: uuidv4(),
       role: 'user',
+      type: 'user',
       content: inputMessage,
       timestamp: Date.now(),
     };
@@ -188,6 +189,7 @@ function App() {
       const assistantMessage = {
         id: uuidv4(),
         role: 'assistant',
+        type: 'ai',
         content: response.answer,
         timestamp: Date.now(),
         sources: response.sources || [],
@@ -207,6 +209,7 @@ function App() {
       const errorMessage = {
         id: uuidv4(),
         role: 'assistant',
+        type: 'ai',
         content: error.message || 'An error occurred while fetching the response.',
         timestamp: Date.now(),
         sources: [],

--- a/src/components/NotebookView.js
+++ b/src/components/NotebookView.js
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { combineMessagesIntoConversations } from '../utils/messageUtils';
+import { combineMessagesIntoConversations, mergeCurrentAndStoredMessages } from '../utils/messageUtils';
 import { Cloud, Smartphone } from 'lucide-react';
 
 const NotebookView = memo(({
@@ -14,8 +14,11 @@ const NotebookView = memo(({
   searchTerm = '',
   sortOrder = 'desc'
 }) => {
-  // Use ALL available messages - try thirtyDayMessages first, fallback to messages
-  const availableMessages = thirtyDayMessages.length > 0 ? thirtyDayMessages : messages;
+  // Merge current session and stored messages
+  const availableMessages = useMemo(
+    () => mergeCurrentAndStoredMessages(messages, thirtyDayMessages),
+    [messages, thirtyDayMessages]
+  );
 
   // Convert to conversations
   const baseConversations = useMemo(

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -159,7 +159,7 @@ class NeonService {
         )
         .map(msg => ({
           ...msg,
-          type: msg.type || msg.role,
+          type: msg.type || (msg.role === 'assistant' ? 'ai' : msg.role),
         }));
 
       if (validMessages.length === 0) {
@@ -333,9 +333,10 @@ class NeonService {
       return [];
     }
 
-    const allMessages = conversations.flatMap(conversation => 
+    const allMessages = conversations.flatMap(conversation =>
       (conversation.messages || []).map(msg => ({
         ...msg,
+        type: msg.type === 'assistant' ? 'ai' : msg.type,
         isStored: true,
         isCurrent: false,
         conversationId: conversation.id,

--- a/src/utils/messageUtils.js
+++ b/src/utils/messageUtils.js
@@ -122,14 +122,21 @@ export function combineMessagesIntoConversations(messages) {
     return [];
   }
 
+  const getType = (msg) => {
+    const t = msg.type || msg.role;
+    return t === 'assistant' ? 'ai' : t;
+  };
+
   return messages.reduce((acc, message, index, array) => {
+    const messageType = getType(message);
+
     // Skip user messages that have a following AI message (they'll be combined)
-    if (message.type === 'user' && index < array.length - 1 && array[index + 1].type === 'ai') {
+    if (messageType === 'user' && index < array.length - 1 && getType(array[index + 1]) === 'ai') {
       return acc;
     }
-    
+
     // Combine AI message with preceding user message
-    if (message.type === 'ai' && index > 0 && array[index - 1].type === 'user') {
+    if (messageType === 'ai' && index > 0 && getType(array[index - 1]) === 'user') {
       const userMessage = array[index - 1];
       const combinedMessage = {
         id: `${userMessage.id}-${message.id}`,
@@ -145,9 +152,9 @@ export function combineMessagesIntoConversations(messages) {
         isStored: message.isStored && userMessage.isStored
       };
       acc.push(combinedMessage);
-    } 
+    }
     // Handle standalone AI messages (like welcome messages)
-    else if (message.type === 'ai') {
+    else if (messageType === 'ai') {
       const combinedMessage = {
         id: message.id,
         userContent: null,
@@ -160,9 +167,9 @@ export function combineMessagesIntoConversations(messages) {
         isStored: message.isStored || false
       };
       acc.push(combinedMessage);
-    } 
+    }
     // Handle standalone user messages (unlikely but possible)
-    else if (message.type === 'user') {
+    else if (messageType === 'user') {
       const combinedMessage = {
         id: message.id,
         userContent: message.content,
@@ -176,7 +183,7 @@ export function combineMessagesIntoConversations(messages) {
       };
       acc.push(combinedMessage);
     }
-    
+
     return acc;
   }, []);
 }


### PR DESCRIPTION
## Summary
- add explicit message `type` fields so conversations are recognized
- merge current and stored messages in notebook view
- normalize message types when saving and loading conversations

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bd968e39d4832abe29fc3a165f8ad5