### PR TITLE
Include resources in assistant messages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -175,6 +175,7 @@ function App() {
       type: 'user',
       content: inputMessage,
       timestamp: Date.now(),
+      resources: [],
     };
 
     // Add user's message immediately
@@ -193,6 +194,7 @@ function App() {
         content: response.answer,
         timestamp: Date.now(),
         sources: response.sources || [],
+        resources: response.resources || [],
       };
 
       setMessages((prev) => [...prev, assistantMessage]);
@@ -213,6 +215,7 @@ function App() {
         content: error.message || 'An error occurred while fetching the response.',
         timestamp: Date.now(),
         sources: [],
+        resources: [],
       };
       setMessages((prev) => [...prev, errorMessage]);
     } finally {


### PR DESCRIPTION
## Summary
- Add empty `resources` arrays to user and error messages
- Attach `resources` from API responses to assistant messages so Sidebar can surface them

## Testing
- `npm test -- --watchAll=false`
- `node - <<'NODE' ... NODE` (resource extraction sanity check)

------
https://chatgpt.com/codex/tasks/task_e_68bda509c5b8832abbe4d76cb068f518