### PR TITLE
Reposition brain icon and clean up resource center text

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -132,13 +132,7 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate }
       <div className="mb-6">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h3 className="text-lg font-bold text-gray-900 mb-2 flex items-center space-x-2">
-              <Brain className="h-5 w-5 text-purple-600" />
-              <span>Learning Center</span>
-            </h3>
-            <p className="text-sm text-gray-500">
-              Personalized recommendations and curated resources
-            </p>
+            <h3 className="text-lg font-bold text-gray-900 mb-2">Learning Center</h3>
           </div>
           {activeTab === 'suggestions' && (
             <button
@@ -277,6 +271,9 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate }
         {/* Resources Tab */}
         {activeTab === 'resources' && (
           <div className="space-y-4">
+            <div className="flex justify-center mb-4">
+              <Brain className="h-5 w-5 text-purple-600" />
+            </div>
             {currentResources.length > 0 ? (
               filteredResources.length > 0 ? (
                 filteredResources.map((resource, index) => (

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -24,17 +24,16 @@ const Sidebar = ({
   return (
     <div className="h-full flex flex-col bg-white rounded-lg shadow-sm border border-gray-200 lg:min-h-0">
       {/* Sidebar Header */}
-      <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 bg-gray-50 rounded-t-lg">
-        <h3 className="text-base sm:text-lg font-semibold text-gray-900">
-          {showNotebook ? 'Conversation History' : 'Learning Center'}
-        </h3>
-        <p className="text-xs sm:text-sm text-gray-600 mt-1">
-          {showNotebook 
-            ? 'Review and export your conversations' 
-            : 'AI-powered suggestions and quality resources'
-          }
-        </p>
-      </div>
+        <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 bg-gray-50 rounded-t-lg">
+          <h3 className="text-base sm:text-lg font-semibold text-gray-900">
+            {showNotebook ? 'Conversation History' : 'Learning Center'}
+          </h3>
+          {showNotebook && (
+            <p className="text-xs sm:text-sm text-gray-600 mt-1">
+              Review and export your conversations
+            </p>
+          )}
+        </div>
 
       {/* Sidebar Content */}
       <div className="flex-1 min-h-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- remove tagline from Learning Center sidebar
- move brain icon into main Resources tab and clean up header

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bda9236f94832a84fc8c75c617988a