### PR TITLE
chore: adjust learning center suggestions header

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -215,12 +215,9 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate }
                   <div className="flex items-center space-x-2 mb-2">
                     <Brain className="h-4 w-4 text-purple-600" />
                     <span className="text-sm font-medium text-purple-800">
-                      Based on Your Recent Conversations
+                      Suggestions Based on Your Recent Conversations
                     </span>
                   </div>
-                  <p className="text-xs text-purple-600">
-                    These suggestions are tailored to help you advance your pharmaceutical quality expertise
-                  </p>
                 </div>
 
                 {/* Suggestions List */}


### PR DESCRIPTION
## Summary
- update learning center header to "Suggestions Based on Your Recent Conversations"
- remove extra tagline below suggestions header

## Testing
- `CI=true npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bdabb77db4832aac0c9c4486d3306d