### PR TITLE
fix: clean ResourcesView header comment

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -1,4 +1,4 @@
-// src/components/ResourcesView.js - Enhanced with Learning Suggestions
+// Enhanced with Learning Suggestions
 import React, { memo, useState, useEffect } from 'react';
 import { Search, ChevronRight, ExternalLink, BookOpen, Brain, RefreshCw, Sparkles, Target, Award } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';


### PR DESCRIPTION
## Summary
- remove outdated header comment from ResourcesView
- keep learning suggestions view intact

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdb6fa33ac832a87ff26df1dda7d82