### PR TITLE
Add notebook save buttons for learning center resources

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -291,6 +291,20 @@ function App() {
     // Could trigger additional UI updates or analytics here
   }, []);
 
+  const handleAddResourceToNotebook = useCallback((item) => {
+    if (!item || !item.title) return;
+    const { title, url = '', type = item.type || 'Resource' } = item;
+    const newMessage = {
+      id: uuidv4(),
+      role: 'assistant',
+      type: 'ai',
+      content: `${title}${url ? ' - ' + url : ''}`,
+      timestamp: Date.now(),
+      resources: [{ title, url, type }],
+    };
+    setMessages(prev => [...prev, newMessage]);
+  }, [setMessages]);
+
   const handleShowRAGConfig = useCallback(() => setShowRAGConfig(true), []);
   const handleCloseRAGConfig = useCallback(() => setShowRAGConfig(false), []);
   const handleShowAdmin = useCallback(() => setShowAdmin(true), []);
@@ -363,6 +377,7 @@ function App() {
                     learningSuggestions={learningSuggestions}
                     isLoadingSuggestions={isLoadingSuggestions}
                     onSuggestionsUpdate={handleSuggestionsUpdate}
+                    onAddResource={handleAddResourceToNotebook}
                   />
                 </div>
               </div>
@@ -403,6 +418,7 @@ function App() {
                     learningSuggestions={learningSuggestions}
                     isLoadingSuggestions={isLoadingSuggestions}
                     onSuggestionsUpdate={handleSuggestionsUpdate}
+                    onAddResource={handleAddResourceToNotebook}
                   />
                 </div>
               </div>

--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -1,9 +1,9 @@
 // Enhanced with Learning Suggestions
 import React, { memo, useState, useEffect } from 'react';
-import { Search, ChevronRight, ExternalLink, BookOpen, Brain, Sparkles, Target, Award } from 'lucide-react';
+import { Search, ChevronRight, ExternalLink, BookOpen, Brain, Sparkles, Target, Award, BookmarkPlus } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';
 
-const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate }) => {
+const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, onAddResource }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [filteredResources, setFilteredResources] = useState(currentResources);
   const [learningSuggestions, setLearningSuggestions] = useState([]);
@@ -193,6 +193,7 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate }
                     getDifficultyColor={getDifficultyColor}
                     getTypeIcon={getTypeIcon}
                     index={index}
+                    onAdd={() => onAddResource && onAddResource(suggestion)}
                   />
                 ))}
 
@@ -243,6 +244,7 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate }
                     resource={resource}
                     onClick={() => handleResourceClick(resource)}
                     colorClass={resourceTypeColors[resource.type] || resourceTypeColors['Reference']}
+                    onAdd={() => onAddResource && onAddResource(resource)}
                   />
                 ))
               ) : (
@@ -278,7 +280,7 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate }
 });
 
 // Individual suggestion card component
-const SuggestionCard = memo(({ suggestion, onClick, getDifficultyColor, getTypeIcon, index }) => {
+const SuggestionCard = memo(({ suggestion, onClick, getDifficultyColor, getTypeIcon, index, onAdd }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
@@ -316,12 +318,21 @@ const SuggestionCard = memo(({ suggestion, onClick, getDifficultyColor, getTypeI
               </span>
             )}
           </div>
-          
-          <ChevronRight 
-            className={`h-4 w-4 text-gray-400 group-hover:text-purple-600 transition-all ml-3 flex-shrink-0 ${
-              isHovered ? 'translate-x-1' : ''
-            }`}
-          />
+
+          <div className="flex items-center space-x-1">
+            <button
+              onClick={(e) => { e.stopPropagation(); onAdd?.(); }}
+              className="p-1 text-gray-400 hover:text-purple-600"
+              aria-label="Add to notebook"
+            >
+              <BookmarkPlus className="h-4 w-4" />
+            </button>
+            <ChevronRight
+              className={`h-4 w-4 text-gray-400 group-hover:text-purple-600 transition-all flex-shrink-0 ${
+                isHovered ? 'translate-x-1' : ''
+              }`}
+            />
+          </div>
         </div>
         
         <h4 className="font-semibold text-gray-900 group-hover:text-purple-800 mb-2 leading-snug">
@@ -377,7 +388,7 @@ const SuggestionCard = memo(({ suggestion, onClick, getDifficultyColor, getTypeI
 });
 
 // Individual resource card component (existing)
-const ResourceCard = memo(({ resource, onClick, colorClass }) => {
+const ResourceCard = memo(({ resource, onClick, colorClass, onAdd }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
@@ -399,7 +410,7 @@ const ResourceCard = memo(({ resource, onClick, colorClass }) => {
         <div className="flex items-start justify-between">
           <div className="flex-1 min-w-0">
             <div className="flex items-center space-x-2 mb-3">
-              <span 
+              <span
                 className={`text-xs font-semibold uppercase tracking-wide px-2 py-1 rounded-full border ${colorClass}`}
               >
                 {resource.type}
@@ -418,11 +429,20 @@ const ResourceCard = memo(({ resource, onClick, colorClass }) => {
             </div>
           </div>
           
-          <ChevronRight 
-            className={`h-4 w-4 text-gray-400 group-hover:text-black transition-all ml-3 flex-shrink-0 ${
-              isHovered ? 'translate-x-1' : ''
-            }`}
-          />
+          <div className="flex items-center space-x-1">
+            <button
+              onClick={(e) => { e.stopPropagation(); onAdd?.(); }}
+              className="p-1 text-gray-400 hover:text-blue-600"
+              aria-label="Add to notebook"
+            >
+              <BookmarkPlus className="h-4 w-4" />
+            </button>
+            <ChevronRight
+              className={`h-4 w-4 text-gray-400 group-hover:text-black transition-all flex-shrink-0 ${
+                isHovered ? 'translate-x-1' : ''
+              }`}
+            />
+          </div>
         </div>
         
         {/* Progress indicator for known long resources */}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -19,7 +19,8 @@ const Sidebar = ({
   user,
   learningSuggestions = [],
   isLoadingSuggestions = false,
-  onSuggestionsUpdate
+  onSuggestionsUpdate,
+  onAddResource
 }) => {
   return (
     <div className="h-full flex flex-col bg-white rounded-lg shadow-sm border border-gray-200 lg:min-h-0">
@@ -58,6 +59,7 @@ const Sidebar = ({
             learningSuggestions={learningSuggestions}
             isLoadingSuggestions={isLoadingSuggestions}
             onSuggestionsUpdate={onSuggestionsUpdate}
+            onAddResource={onAddResource}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Allow users to save learning resources and AI suggestions directly to the notebook
- Wire learning center cards to a new handler that stores the item as an assistant message

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbd0a5f80832a8fb2b7d35a2f8ce3