### PR TITLE
feat: hide learning resource messages from chat

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -301,6 +301,8 @@ function App() {
       content: `${title}${url ? ' - ' + url : ''}`,
       timestamp: Date.now(),
       resources: [{ title, url, type }],
+      // Mark message so it can be hidden from the chat area
+      isResource: true,
     };
     setMessages(prev => [...prev, newMessage]);
   }, [setMessages]);

--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -95,7 +95,7 @@ const ChatArea = ({
           </div>
         ) : (
           <>
-            {messages.map((message, index) => (
+            {messages.filter(message => !message.isResource).map((message, index) => (
               <div key={index} className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                 <div className={`max-w-[85%] lg:max-w-[75%] p-3 sm:p-4 rounded-lg ${
                   message.role === 'user'


### PR DESCRIPTION
## Summary
- mark added learning resources so they don't render in chat
- filter resource messages from ChatArea display

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb135354832a8b0a2aa2febf41d4