### PR TITLE
feat: show resource added timestamp in notebook

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -300,7 +300,7 @@ function App() {
       type: 'ai',
       content: `${title}${url ? ' - ' + url : ''}`,
       timestamp: Date.now(),
-      resources: [{ title, url, type }],
+      resources: [{ title, url, type, addedAt: Date.now() }],
       // Mark message so it can be hidden from the chat area
       isResource: true,
     };

--- a/src/components/NotebookView.js
+++ b/src/components/NotebookView.js
@@ -90,7 +90,7 @@ const NotebookView = memo(({
     conversations.forEach(conv => {
       (conv.resources || []).forEach(res => {
         if (res.url && res.title) {
-          map.set(res.url, res);
+          map.set(res.url, { ...res, addedAt: res.addedAt || conv.timestamp });
         }
       });
     });
@@ -276,7 +276,12 @@ const NotebookView = memo(({
                     className="text-sm font-medium text-blue-600 hover:text-blue-800 block truncate">
                     {resource.title}
                   </a>
-                  <span className="text-xs text-gray-500">{resource.type}</span>
+                  <span className="text-xs text-gray-500">
+                    {resource.type}
+                    {resource.addedAt && (
+                      <> • {new Date(resource.addedAt).toLocaleString()}</>
+                    )}
+                  </span>
                 </div>
               ))
             )}


### PR DESCRIPTION
## Summary
- add `addedAt` timestamp when resources are saved to notebook
- render resource timestamps in notebook view

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bddb30b854832a8f61b609158bbbf9