### PR TITLE
feat: add AI suggestions feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,13 @@ REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 # Get your connection string from: https://console.neon.tech/
 NEON_DATABASE_URL=postgresql://username:password@hostname/database?sslmode=require
 
+# Feature Flags
+# Set to 'false' to disable AI suggestions
+REACT_APP_ENABLE_AI_SUGGESTIONS=true
+
 # Example values (DO NOT USE IN PRODUCTION):
 # REACT_APP_OPENAI_API_KEY=sk-proj-abc123...
-# REACT_APP_AUTH0_DOMAIN=acceleraqa-dev.us.auth0.com  
+# REACT_APP_AUTH0_DOMAIN=acceleraqa-dev.us.auth0.com
 # REACT_APP_AUTH0_CLIENT_ID=abc123xyz789
 # REACT_APP_AUTH0_AUDIENCE=https://api.acceleraqa.com
 # NEON_DATABASE_URL=postgresql://user:pass@ep-cool-morning-123456.us-east-2.aws.neon.tech/neondb?sslmode=require

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 
 # Neon PostgreSQL (Required for database features)
 NEON_DATABASE_URL=postgresql://username:password@hostname/database?sslmode=require
+
+# Feature Flags (Optional)
+REACT_APP_ENABLE_AI_SUGGESTIONS=true # set to 'false' to disable AI suggestions
 ```
 
 ### 4. Auth0 Configuration
@@ -173,8 +176,9 @@ npm run build
 ### Environment Variables in Netlify:
 ```bash
 REACT_APP_AUTH0_DOMAIN=your-domain.auth0.com
-REACT_APP_AUTH0_CLIENT_ID=your_client_id  
+REACT_APP_AUTH0_CLIENT_ID=your_client_id
 REACT_APP_OPENAI_API_KEY=your_openai_key
+REACT_APP_ENABLE_AI_SUGGESTIONS=true # optional: set to 'false' to disable AI suggestions
 ```
 
 ## 🔍 Troubleshooting

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -52,9 +52,14 @@ export const UI_CONFIG = {
   PAGINATION_SIZE: 20
 };
 
+// Feature Flags
+export const FEATURE_FLAGS = {
+  ENABLE_AI_SUGGESTIONS: process.env.REACT_APP_ENABLE_AI_SUGGESTIONS !== 'false'
+};
+
 // Enhanced Error Messages with troubleshooting
 export const ERROR_MESSAGES = {
-  API_KEY_NOT_CONFIGURED: `⚠️ OpenAI API key not configured. 
+  API_KEY_NOT_CONFIGURED: `⚠️ OpenAI API key not configured.
 
 TROUBLESHOOTING STEPS:
 1. Check that REACT_APP_OPENAI_API_KEY is set in your environment


### PR DESCRIPTION
## Summary
- add FEATURE_FLAGS with ENABLE_AI_SUGGESTIONS defaulting to true unless REACT_APP_ENABLE_AI_SUGGESTIONS is 'false'
- document REACT_APP_ENABLE_AI_SUGGESTIONS in setup and Netlify environment variable examples

## Testing
- `CI=true npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bde5870f14832aa67e00811b7e51e1