### PR TITLE
Gate AI suggestions behind feature flag

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -2,13 +2,14 @@
 import React, { memo, useState, useEffect, useRef } from 'react';
 import { Search, ChevronRight, ExternalLink, BookOpen, Brain, Sparkles, Target, Award, BookmarkPlus, Check } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';
+import { FEATURE_FLAGS } from '../config/featureFlags';
 
 const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, onAddResource }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [filteredResources, setFilteredResources] = useState(currentResources);
   const [learningSuggestions, setLearningSuggestions] = useState([]);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
-  const [activeTab, setActiveTab] = useState('suggestions'); // 'suggestions' or 'resources'
+  const [activeTab, setActiveTab] = useState('resources'); // 'suggestions' or 'resources'
   const [showAllSuggestions, setShowAllSuggestions] = useState(false);
   const [addedResources, setAddedResources] = useState(new Set());
   const [showToast, setShowToast] = useState(false);
@@ -16,7 +17,7 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
 
   // Load learning suggestions on component mount and user change
   useEffect(() => {
-    if (user?.sub) {
+    if (FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS && user?.sub) {
       loadLearningSuggestions();
     }
   }, [user]);
@@ -35,7 +36,7 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
   }, [currentResources, searchTerm]);
 
   const loadLearningSuggestions = async () => {
-    if (!user?.sub) return;
+    if (!FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS || !user?.sub) return;
 
     setIsLoadingSuggestions(true);
     try {
@@ -142,22 +143,24 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
       <div className="mb-6">
         {/* Tab Navigation */}
         <div className="flex space-x-1 mb-4">
-          <button
-            onClick={() => setActiveTab('suggestions')}
-            className={`flex items-center space-x-2 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
-              activeTab === 'suggestions'
-                ? 'bg-purple-100 text-purple-700 border border-purple-200'
-                : 'text-gray-600 hover:text-gray-800 hover:bg-gray-100'
-            }`}
-          >
-            <Sparkles className="h-4 w-4" />
-            <span>AI Suggestions</span>
-            {learningSuggestions.length > 0 && (
-              <span className="bg-purple-600 text-white text-xs px-1.5 py-0.5 rounded-full">
-                {learningSuggestions.length}
-              </span>
-            )}
-          </button>
+          {FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS && (
+            <button
+              onClick={() => setActiveTab('suggestions')}
+              className={`flex items-center space-x-2 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+                activeTab === 'suggestions'
+                  ? 'bg-purple-100 text-purple-700 border border-purple-200'
+                  : 'text-gray-600 hover:text-gray-800 hover:bg-gray-100'
+              }`}
+            >
+              <Sparkles className="h-4 w-4" />
+              <span>AI Suggestions</span>
+              {learningSuggestions.length > 0 && (
+                <span className="bg-purple-600 text-white text-xs px-1.5 py-0.5 rounded-full">
+                  {learningSuggestions.length}
+                </span>
+              )}
+            </button>
+          )}
           <button
             onClick={() => setActiveTab('resources')}
             className={`flex items-center space-x-2 px-3 py-2 text-sm font-medium rounded-md transition-colors ${
@@ -194,7 +197,7 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
       {/* Content Area */}
       <div className="flex-1 overflow-y-auto">
         {/* AI Suggestions Tab */}
-        {activeTab === 'suggestions' && (
+        {FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS && activeTab === 'suggestions' && (
           <div className="space-y-4">
             {isLoadingSuggestions ? (
               <div className="text-center py-8">

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import NotebookView from './NotebookView';
 import ResourcesView from './ResourcesView';
+import { FEATURE_FLAGS } from '../config/featureFlags';
 
 const Sidebar = ({
   showNotebook,
@@ -65,47 +66,49 @@ const Sidebar = ({
       </div>
 
       {/* Enhanced Footer with Learning Status */}
-      <div className="flex-shrink-0 px-4 py-3 border-t border-gray-200 bg-gray-50 rounded-b-lg">
-        <div className="flex items-center justify-between text-xs text-gray-500">
-          <span>
-            {showNotebook 
-              ? `${thirtyDayMessages?.length || 0} conversations`
-              : `${learningSuggestions.length} AI suggestions`
-            }
-          </span>
-          
-          <div className="flex items-center space-x-2">
-            {/* Learning Status Indicator */}
-            {!showNotebook && (
-              <>
-                {isLoadingSuggestions ? (
-                  <div className="flex items-center space-x-1 text-purple-600">
-                    <div className="animate-spin rounded-full h-3 w-3 border border-purple-600 border-t-transparent"></div>
-                    <span>Learning...</span>
-                  </div>
-                ) : learningSuggestions.length > 0 ? (
-                  <div className="flex items-center space-x-1 text-green-600">
-                    <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                    <span>Personalized</span>
-                  </div>
-                ) : (
-                  <span className="text-gray-400">Start chatting</span>
-                )}
-              </>
-            )}
-            
-            {isServerAvailable && showNotebook && (
-              <button
-                onClick={onRefresh}
-                className="text-blue-600 hover:text-blue-800 font-medium"
-                title="Refresh from cloud"
-              >
-                Refresh
-              </button>
-            )}
+      {(showNotebook || FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS) && (
+        <div className="flex-shrink-0 px-4 py-3 border-t border-gray-200 bg-gray-50 rounded-b-lg">
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>
+              {showNotebook
+                ? `${thirtyDayMessages?.length || 0} conversations`
+                : `${learningSuggestions.length} AI suggestions`
+              }
+            </span>
+
+            <div className="flex items-center space-x-2">
+              {/* Learning Status Indicator */}
+              {!showNotebook && FEATURE_FLAGS.ENABLE_AI_SUGGESTIONS && (
+                <>
+                  {isLoadingSuggestions ? (
+                    <div className="flex items-center space-x-1 text-purple-600">
+                      <div className="animate-spin rounded-full h-3 w-3 border border-purple-600 border-t-transparent"></div>
+                      <span>Learning...</span>
+                    </div>
+                  ) : learningSuggestions.length > 0 ? (
+                    <div className="flex items-center space-x-1 text-green-600">
+                      <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                      <span>Personalized</span>
+                    </div>
+                  ) : (
+                    <span className="text-gray-400">Start chatting</span>
+                  )}
+                </>
+              )}
+
+              {isServerAvailable && showNotebook && (
+                <button
+                  onClick={onRefresh}
+                  className="text-blue-600 hover:text-blue-800 font-medium"
+                  title="Refresh from cloud"
+                >
+                  Refresh
+                </button>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/config/featureFlags.js
+++ b/src/config/featureFlags.js
@@ -1,0 +1,3 @@
+export const FEATURE_FLAGS = {
+  ENABLE_AI_SUGGESTIONS: true,
+};


### PR DESCRIPTION
## Summary
- add FEATURE_FLAGS with ENABLE_AI_SUGGESTIONS
- hide AI Suggestions UI when feature disabled
- load and refresh learning suggestions only when flag enabled

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bde5906a78832aa690f91a5536e198