### PR TITLE
Remove brain icon from Resources tab

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -266,9 +266,6 @@ const ResourcesView = memo(({ currentResources = [], user, onSuggestionsUpdate, 
         {/* Resources Tab */}
         {activeTab === 'resources' && (
           <div className="space-y-4">
-            <div className="flex justify-center mb-4">
-              <Brain className="h-5 w-5 text-purple-600" />
-            </div>
             {currentResources.length > 0 ? (
               filteredResources.length > 0 ? (
                 filteredResources.map((resource, index) => (


### PR DESCRIPTION
## Summary
- remove brain icon from Resources tab in learning center

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bded8cace4832aa9afcab68aa51870