### PR TITLE
feat(admin): manage training resources

### DIFF
--- a/netlify/functions/neon-db.js
+++ b/netlify/functions/neon-db.js
@@ -234,7 +234,13 @@ export const handler = async (event, context) => {
 
       case 'health_check':
         return await handleHealthCheck(sql, userId);
-      
+
+      case 'add_training_resource':
+        return await handleAddTrainingResource(sql, userId, data);
+
+      case 'get_training_resources':
+        return await handleGetTrainingResources(sql, userId);
+
       default:
         return {
           statusCode: 400,
@@ -696,6 +702,63 @@ async function handleAnalyzeConversationsForLearning(sql, userId, data) {
         message: error.message,
         userId: userId
       }),
+    };
+  }
+}
+
+
+// Training resources handlers
+async function handleAddTrainingResource(sql, userId, data) {
+  try {
+    if (!data || !data.name || !data.url) {
+      return {
+        statusCode: 400,
+        headers,
+        body: JSON.stringify({ error: 'Name and URL are required' }),
+      };
+    }
+
+    const { name, description = '', url } = data;
+    const [resource] = await sql`
+      INSERT INTO training_resources (name, description, url)
+      VALUES (${name}, ${description}, ${url})
+      RETURNING id, name, description, url, created_at, updated_at
+    `;
+
+    return {
+      statusCode: 201,
+      headers,
+      body: JSON.stringify({ resource }),
+    };
+  } catch (error) {
+    console.error('❌ Error adding training resource:', error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Failed to add training resource', message: error.message }),
+    };
+  }
+}
+
+async function handleGetTrainingResources(sql, userId) {
+  try {
+    const resources = await sql`
+      SELECT id, name, description, url, created_at, updated_at
+      FROM training_resources
+      ORDER BY created_at DESC
+    `;
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ resources }),
+    };
+  } catch (error) {
+    console.error('❌ Error loading training resources:', error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Failed to load training resources', message: error.message }),
     };
   }
 }

--- a/scripts/setup-neon-database.sql
+++ b/scripts/setup-neon-database.sql
@@ -117,6 +117,18 @@ async function setupNeonDatabase() {
       )
     `;
 
+    // Create training_resources table
+    await sql`
+      CREATE TABLE IF NOT EXISTS training_resources (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        description TEXT,
+        url TEXT NOT NULL,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      )
+    `;
+
     console.log('✅ Database tables created successfully');
 
     // Create indexes for optimal performance
@@ -178,6 +190,17 @@ async function setupNeonDatabase() {
       DO $ BEGIN
         CREATE TRIGGER conversations_updated_at
           BEFORE UPDATE ON conversations
+          FOR EACH ROW
+          EXECUTE FUNCTION update_updated_at();
+      EXCEPTION
+        WHEN duplicate_object THEN null;
+      END $;
+    `;
+
+    await sql`
+      DO $ BEGIN
+        CREATE TRIGGER training_resources_updated_at
+          BEFORE UPDATE ON training_resources
           FOR EACH ROW
           EXECUTE FUNCTION update_updated_at();
       EXCEPTION

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -22,7 +22,8 @@ import {
   Zap,
   Bug,
   Monitor,
-  Search
+  Search,
+  BookOpen
 } from 'lucide-react';
 
 // Import services
@@ -31,6 +32,7 @@ import ragService from '../services/ragService';
 import { getToken, getTokenInfo } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 import RAGConfigurationPage from './RAGConfigurationPage';
+import TrainingResourcesAdmin from './TrainingResourcesAdmin';
 
 export const checkStorageHealth = async () => {
   // Check browser storage capacity
@@ -424,6 +426,7 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'rag', label: 'RAG System', icon: FileText },
               { id: 'ragConfig', label: 'RAG Config', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
+              { id: 'training', label: 'Training Resources', icon: BookOpen },
               { id: 'tools', label: 'Admin Tools', icon: Settings }
             ].map(tab => {
               const Icon = tab.icon;
@@ -725,6 +728,16 @@ const AdminScreen = ({ user, onBack }) => {
                     </div>
                   ))}
                 </div>
+              </div>
+            </div>
+          )}
+
+          {/* Training Resources Tab */}
+          {activeTab === 'training' && (
+            <div className="space-y-6">
+              <div className="bg-white rounded-lg shadow p-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Training Resources</h3>
+                <TrainingResourcesAdmin />
               </div>
             </div>
           )}

--- a/src/components/TrainingResourcesAdmin.js
+++ b/src/components/TrainingResourcesAdmin.js
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from 'react';
+import { PlusCircle } from 'lucide-react';
+import neonService from '../services/neonService';
+
+const TrainingResourcesAdmin = () => {
+  const [resources, setResources] = useState([]);
+  const [form, setForm] = useState({ name: '', description: '', url: '' });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    loadResources();
+  }, []);
+
+  const loadResources = async () => {
+    try {
+      const data = await neonService.getTrainingResources();
+      setResources(data);
+    } catch (err) {
+      console.error('Failed to load training resources:', err);
+      setResources([]);
+    }
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.name.trim() || !form.url.trim()) {
+      setError('Name and URL are required');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const newResource = await neonService.addTrainingResource(form);
+      setResources(prev => [newResource, ...prev]);
+      setForm({ name: '', description: '', url: '' });
+    } catch (err) {
+      console.error('Failed to add training resource:', err);
+      setError(err.message || 'Failed to add resource');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Name</label>
+          <input
+            type="text"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            placeholder="Training title"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Description</label>
+          <textarea
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            rows={3}
+            placeholder="Brief description"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">URL</label>
+          <input
+            type="url"
+            name="url"
+            value={form.url}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            placeholder="https://example.com/training"
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+          >
+            <PlusCircle className="h-4 w-4 mr-2" />
+            Add Resource
+          </button>
+        </div>
+      </form>
+
+      <div>
+        <h3 className="text-lg font-medium text-gray-900 mb-2">Existing Resources</h3>
+        {resources.length === 0 ? (
+          <p className="text-sm text-gray-500">No training resources found.</p>
+        ) : (
+          <ul className="space-y-3">
+            {resources.map(res => (
+              <li key={res.id} className="p-4 border rounded-md">
+                <div className="font-medium">{res.name}</div>
+                {res.description && <p className="text-sm text-gray-500">{res.description}</p>}
+                {res.url && (
+                  <a
+                    href={res.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-blue-600 hover:underline"
+                  >
+                    {res.url}
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TrainingResourcesAdmin;

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -381,6 +381,38 @@ class NeonService {
   }
 
   /**
+   * Training resources management
+   */
+  async addTrainingResource(resource) {
+    try {
+      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'add_training_resource',
+          data: resource
+        })
+      });
+      return result.resource;
+    } catch (error) {
+      console.error('Failed to add training resource:', error);
+      throw error;
+    }
+  }
+
+  async getTrainingResources() {
+    try {
+      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({ action: 'get_training_resources' })
+      });
+      return result.resources || [];
+    } catch (error) {
+      console.error('Failed to load training resources:', error);
+      return [];
+    }
+  }
+
+  /**
    * Check if the service is available
    */
   async isServiceAvailable() {


### PR DESCRIPTION
## Summary
- add Neon table and triggers for training resources
- expose add/list actions in Neon serverless function and client service
- introduce admin UI for managing training resources

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf4643844832aa1ed66343f77c64c