### PR TITLE
feat(admin): manage training resources

### DIFF
--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -22,7 +22,8 @@ import {
   Zap,
   Bug,
   Monitor,
-  Search
+  Search,
+  BookOpen
 } from 'lucide-react';
 
 // Import services
@@ -31,6 +32,7 @@ import ragService from '../services/ragService';
 import { getToken, getTokenInfo } from '../services/authService';
 import { hasAdminRole } from '../utils/auth';
 import RAGConfigurationPage from './RAGConfigurationPage';
+import TrainingResourcesAdmin from './TrainingResourcesAdmin';
 
 export const checkStorageHealth = async () => {
   // Check browser storage capacity
@@ -424,6 +426,7 @@ const AdminScreen = ({ user, onBack }) => {
               { id: 'rag', label: 'RAG System', icon: FileText },
               { id: 'ragConfig', label: 'RAG Config', icon: Search },
               { id: 'system', label: 'System Health', icon: Activity },
+              { id: 'training', label: 'Training Resources', icon: BookOpen },
               { id: 'tools', label: 'Admin Tools', icon: Settings }
             ].map(tab => {
               const Icon = tab.icon;
@@ -725,6 +728,16 @@ const AdminScreen = ({ user, onBack }) => {
                     </div>
                   ))}
                 </div>
+              </div>
+            </div>
+          )}
+
+          {/* Training Resources Tab */}
+          {activeTab === 'training' && (
+            <div className="space-y-6">
+              <div className="bg-white rounded-lg shadow p-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Training Resources</h3>
+                <TrainingResourcesAdmin />
               </div>
             </div>
           )}

--- a/src/components/TrainingResourcesAdmin.js
+++ b/src/components/TrainingResourcesAdmin.js
@@ -1,0 +1,161 @@
+import React, { useState, useEffect } from 'react';
+import { PlusCircle } from 'lucide-react';
+import neonService from '../services/neonService';
+
+const TrainingResourcesAdmin = () => {
+  const [resources, setResources] = useState([]);
+  const [form, setForm] = useState({ name: '', description: '', url: '', tags: '' });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    loadResources();
+  }, []);
+
+  const loadResources = async () => {
+    try {
+      const data = await neonService.getTrainingResources();
+      setResources(data);
+    } catch (err) {
+      console.error('Failed to load training resources:', err);
+      setResources([]);
+    }
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.name.trim() || !form.url.trim()) {
+      setError('Name and URL are required');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const tags = form.tags
+        .split(',')
+        .map(t => t.trim())
+        .filter(Boolean);
+      const newResource = await neonService.addTrainingResource({
+        name: form.name,
+        description: form.description,
+        url: form.url,
+        tags,
+      });
+      setResources(prev => [newResource, ...prev]);
+      setForm({ name: '', description: '', url: '', tags: '' });
+    } catch (err) {
+      console.error('Failed to add training resource:', err);
+      setError(err.message || 'Failed to add resource');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Name</label>
+          <input
+            type="text"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            placeholder="Training title"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Description</label>
+          <textarea
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            rows={3}
+            placeholder="Brief description"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">URL</label>
+          <input
+            type="url"
+            name="url"
+            value={form.url}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            placeholder="https://example.com/training"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Tags</label>
+          <input
+            type="text"
+            name="tags"
+            value={form.tags}
+            onChange={handleChange}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            placeholder="comma, separated, tags"
+          />
+          <p className="text-xs text-gray-500 mt-1">Separate tags with commas</p>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+          >
+            <PlusCircle className="h-4 w-4 mr-2" />
+            Add Resource
+          </button>
+        </div>
+      </form>
+
+      <div>
+        <h3 className="text-lg font-medium text-gray-900 mb-2">Existing Resources</h3>
+        {resources.length === 0 ? (
+          <p className="text-sm text-gray-500">No training resources found.</p>
+        ) : (
+          <ul className="space-y-3">
+            {resources.map(res => (
+              <li key={res.id} className="p-4 border rounded-md">
+                <div className="font-medium">{res.name}</div>
+                {res.description && <p className="text-sm text-gray-500">{res.description}</p>}
+                {res.url && (
+                  <a
+                    href={res.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-blue-600 hover:underline"
+                  >
+                    {res.url}
+                  </a>
+                )}
+                {res.tags && res.tags.length > 0 && (
+                  <div className="mt-2 space-x-1">
+                    {res.tags.map(tag => (
+                      <span
+                        key={tag}
+                        className="inline-block bg-gray-200 text-gray-700 text-xs px-2 py-1 rounded"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TrainingResourcesAdmin;

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -381,6 +381,38 @@ class NeonService {
   }
 
   /**
+   * Training resources management
+   */
+  async addTrainingResource(resource) {
+    try {
+      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'add_training_resource',
+          data: { ...resource, tags: resource.tags || [] }
+        })
+      });
+      return result.resource;
+    } catch (error) {
+      console.error('Failed to add training resource:', error);
+      throw error;
+    }
+  }
+
+  async getTrainingResources() {
+    try {
+      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({ action: 'get_training_resources' })
+      });
+      return (result.resources || []).map(r => ({ ...r, tags: r.tags || [] }));
+    } catch (error) {
+      console.error('Failed to load training resources:', error);
+      return [];
+    }
+  }
+
+  /**
    * Check if the service is available
    */
   async isServiceAvailable() {


### PR DESCRIPTION
## Summary
- add Neon table and triggers for training resources
- expose add/list actions in Neon serverless function and client service
- introduce admin UI for managing training resources
- allow tagging training resources

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf4643844832aa1ed66343f77c64c