### PR TITLE
fix training resource user scoping

### DIFF
--- a/netlify/functions/neon-db.js
+++ b/netlify/functions/neon-db.js
@@ -720,9 +720,9 @@ async function handleAddTrainingResource(sql, userId, data) {
 
     const { name, description = '', url, tag = null } = data;
     const [resource] = await sql`
-      INSERT INTO training_resources (name, description, url, tag)
-      VALUES (${name}, ${description}, ${url}, ${tag})
-      RETURNING id, name, description, url, tag, created_at, updated_at
+      INSERT INTO training_resources (user_id, name, description, url, tag)
+      VALUES (${userId}, ${name}, ${description}, ${url}, ${tag})
+      RETURNING id, user_id, name, description, url, tag, created_at, updated_at
     `;
 
     return {
@@ -743,8 +743,9 @@ async function handleAddTrainingResource(sql, userId, data) {
 async function handleGetTrainingResources(sql, userId) {
   try {
     const resources = await sql`
-      SELECT id, name, description, url, tag, created_at, updated_at
+      SELECT id, user_id, name, description, url, tag, created_at, updated_at
       FROM training_resources
+      WHERE user_id = ${userId}
       ORDER BY created_at DESC
     `;
 

--- a/scripts/setup-neon-database.sql
+++ b/scripts/setup-neon-database.sql
@@ -121,6 +121,7 @@ async function setupNeonDatabase() {
     await sql`
       CREATE TABLE IF NOT EXISTS training_resources (
         id SERIAL PRIMARY KEY,
+        user_id VARCHAR(255) NOT NULL,
         name VARCHAR(255) NOT NULL,
         description TEXT,
         url TEXT NOT NULL,
@@ -157,6 +158,9 @@ async function setupNeonDatabase() {
     await sql`CREATE INDEX IF NOT EXISTS idx_conversations_user_id ON conversations(user_id)`;
     await sql`CREATE INDEX IF NOT EXISTS idx_conversations_created ON conversations(user_id, created_at DESC)`;
     await sql`CREATE INDEX IF NOT EXISTS idx_conversations_rag ON conversations(user_id, used_rag)`;
+
+    // Training resources indexes
+    await sql`CREATE INDEX IF NOT EXISTS idx_training_resources_user_id ON training_resources(user_id)`;
 
     // Full-text search indexes
     await sql`CREATE INDEX IF NOT EXISTS idx_rag_documents_fts ON rag_documents USING gin(to_tsvector('english', text_content))`;


### PR DESCRIPTION
## Summary
- tie training resource records to each user ID
- add database user_id column and index for training resources

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdfe3ad220832abfbf45662e88263b