### PR TITLE
Improve training resource endpoint handling

### DIFF
--- a/netlify/functions/neon-db.js
+++ b/netlify/functions/neon-db.js
@@ -708,7 +708,7 @@ async function handleAnalyzeConversationsForLearning(sql, userId, data) {
 
 
 // Training resources handlers
-async function handleAddTrainingResource(sql, userId, data) {
+export async function handleAddTrainingResource(sql, userId, data) {
   try {
     if (!data || !data.name || !data.url) {
       return {
@@ -732,15 +732,38 @@ async function handleAddTrainingResource(sql, userId, data) {
     };
   } catch (error) {
     console.error('❌ Error adding training resource:', error);
+    if (error.code === '42P01') {
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({
+          error: 'training_resources table is missing',
+          message: error.message,
+        }),
+      };
+    }
+    if (error.code === '42703') {
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({
+          error: 'A required column is missing',
+          message: error.message,
+        }),
+      };
+    }
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ error: 'Failed to add training resource', message: error.message }),
+      body: JSON.stringify({
+        error: 'Failed to add training resource',
+        message: error.message,
+      }),
     };
   }
 }
 
-async function handleGetTrainingResources(sql, userId) {
+export async function handleGetTrainingResources(sql, userId) {
   try {
     const resources = await sql`
       SELECT id, user_id, name, description, url, tag, created_at, updated_at
@@ -756,10 +779,33 @@ async function handleGetTrainingResources(sql, userId) {
     };
   } catch (error) {
     console.error('❌ Error loading training resources:', error);
+    if (error.code === '42P01') {
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({
+          error: 'training_resources table is missing',
+          message: error.message,
+        }),
+      };
+    }
+    if (error.code === '42703') {
+      return {
+        statusCode: 500,
+        headers,
+        body: JSON.stringify({
+          error: 'A required column is missing',
+          message: error.message,
+        }),
+      };
+    }
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ error: 'Failed to load training resources', message: error.message }),
+      body: JSON.stringify({
+        error: 'Failed to load training resources',
+        message: error.message,
+      }),
     };
   }
 }

--- a/src/neon-db.test.js
+++ b/src/neon-db.test.js
@@ -1,0 +1,50 @@
+import { handleAddTrainingResource, handleGetTrainingResources } from '../netlify/functions/neon-db.js';
+
+describe('training resource handlers', () => {
+  test('add_training_resource includes user_id', async () => {
+    const calls = [];
+    const sql = async (strings, ...values) => {
+      calls.push({ query: strings.join(''), values });
+      return [{ id: 1, user_id: values[0], name: values[1], description: values[2], url: values[3], tag: values[4], created_at: '', updated_at: '' }];
+    };
+    const res = await handleAddTrainingResource(sql, 'user1', { name: 'Doc', description: 'd', url: 'http://x', tag: 'tag1' });
+    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(201);
+    expect(body.resource.user_id).toBe('user1');
+    expect(calls[0].values[0]).toBe('user1');
+  });
+
+  test('get_training_resources filters by user_id', async () => {
+    const sql = async (strings, ...values) => {
+      return [{ id: 2, user_id: values[0], name: 'Doc', description: '', url: 'http://x', tag: null, created_at: '', updated_at: '' }];
+    };
+    const res = await handleGetTrainingResources(sql, 'user2');
+    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(200);
+    expect(body.resources.every(r => r.user_id === 'user2')).toBe(true);
+  });
+
+  test('add_training_resource handles missing table', async () => {
+    const sql = async () => {
+      const err = new Error('relation "training_resources" does not exist');
+      err.code = '42P01';
+      throw err;
+    };
+    const res = await handleAddTrainingResource(sql, 'user1', { name: 'Doc', url: 'http://x' });
+    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(500);
+    expect(body.error).toMatch(/table/i);
+  });
+
+  test('get_training_resources handles missing column', async () => {
+    const sql = async () => {
+      const err = new Error('column "user_id" does not exist');
+      err.code = '42703';
+      throw err;
+    };
+    const res = await handleGetTrainingResources(sql, 'user1');
+    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(500);
+    expect(body.error).toMatch(/column/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add specific table/column error handling to training resource endpoints
- expose training resource handlers for testing
- add tests ensuring user-scoped queries and error cases

## Testing
- `npm run setup:neon` *(fails: NEON_DATABASE_URL environment variable is not set)*
- `CI=true npm test src/neon-db.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68be07dd927c832a8f0324df55cf238a