### PR TITLE
Persist RAG document chunks to Neon database

### DIFF
--- a/src/services/authService.test.js
+++ b/src/services/authService.test.js
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
+import { TextEncoder, TextDecoder } from 'util';
 import { hasAdminRole } from '../utils/auth';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
 
 describe('AuthService getUser', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- write RAG documents and their chunks to Neon PostgreSQL
- query Neon for listing, deleting, searching, and stats
- polyfill TextEncoder/TextDecoder in auth service tests

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf4aa090c0832abfaa99ffe8c08acf