### PR TITLE
Add RAG search method and hook into app

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ import NotebookOverlay from './components/NotebookOverlay';
 // Utility
 import { v4 as uuidv4 } from 'uuid';
 import authService, { initializeAuth } from './services/authService';
-import ragService from './services/ragService';
+import { search as ragSearch } from './services/ragService';
 import openaiService from './services/openaiService';
 
 import { initializeNeonService, loadConversations as loadNeonConversations, saveConversation as saveNeonConversation } from './services/neonService';
@@ -188,7 +188,7 @@ function App() {
 
     try {
       const response = ragEnabled
-        ? await ragService.search(inputMessage)
+        ? await ragSearch(inputMessage)
         : await openaiService.getChatResponse(inputMessage);
 
       const assistantMessage = {

--- a/src/services/ragService.js
+++ b/src/services/ragService.js
@@ -1,7 +1,6 @@
 // src/services/ragService.js - Updated RAG service with FIXED authentication
 import openaiService from './openaiService';
 import authService, { getToken } from './authService';
-import mammoth from 'mammoth';
 
 const API_BASE_URL = '/.netlify/functions';
 
@@ -377,6 +376,22 @@ Answer:`;
     }
   }
 
+  async search(query, options = {}) {
+    try {
+      const searchData = await this.searchDocuments(query, options);
+      const matches = searchData.results || [];
+      const response = await this.generateRAGResponse(query, matches);
+      return {
+        answer: response.answer,
+        sources: response.sources || matches,
+        resources: response.resources || []
+      };
+    } catch (error) {
+      console.error('Error performing RAG search:', error);
+      throw error;
+    }
+  }
+
   async getStats() {
     try {
       const result = await this.makeAuthenticatedRequest(this.apiUrl, {
@@ -568,6 +583,7 @@ export default ragService;
 
 // Export convenience functions
 export const uploadDocument = (file, metadata) => ragService.uploadDocument(file, metadata);
+export const search = (query, options) => ragService.search(query, options);
 export const searchDocuments = (query, options) => ragService.searchDocuments(query, options);
 export const getDocuments = () => ragService.getDocuments();
 export const deleteDocument = (documentId) => ragService.deleteDocument(documentId);


### PR DESCRIPTION
## Summary
- provide `search` helper in RAG service that runs document search and composes RAG response
- export convenience wrapper and update App to use the new helper

## Testing
- `npm test`
- `npm start` *(fails: interactive run requires manual browser interaction, build outputs warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf65234e38832ab532943249224c52