### PR TITLE
Fix package.json dependencies syntax for openai

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "latest",
     "react-scripts": "5.0.1",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
     "openai": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add missing comma between `ws` and `openai` dependencies

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`


------
https://chatgpt.com/codex/tasks/task_e_68c0b640ef48832a8a5a622e9247d3e8