### PR TITLE
fix package.json syntax and use npm ci for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "build"
-  command = "npm run build"
+  command = "npm ci && npm run build"
   functions = "netlify/functions"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "latest",
     "react-scripts": "5.0.1",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
     "openai": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- fix invalid dependency list in package.json
- ensure Netlify build executes `npm ci` for reproducible installs

## Testing
- `npm test` *(fails: react-scripts not found, dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b6438160832ab1a2134d9f317ba1