### PR TITLE
Add Auth0 React SDK dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,18 +5,19 @@
   "description": "AI-powered learning assistant for pharmaceutical quality and compliance professionals with Neon PostgreSQL storage",
   "homepage": "https://acceleraqa.com",
   "dependencies": {
+    "@auth0/auth0-react": "^2.1.3",
     "@auth0/auth0-spa-js": "^2.1.3",
     "@neondatabase/serverless": "^0.9.0",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.1.5",
     "lucide-react": "^0.263.1",
     "mammoth": "^1.6.0",
+    "openai": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.8.2",
     "react-scripts": "5.0.1",
-    "ws": "^8.18.0",
-    "openai": "^4.0.0"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.7",


### PR DESCRIPTION
## Summary
- fix Netlify build by adding missing `@auth0/auth0-react` dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@auth0%2fauth0-react)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bae7f798832a9b0b4931bf7af7aa