### PR TITLE
Fix ChatArea input initialization to prevent split error

### DIFF
--- a/src/components/ChatArea.js
+++ b/src/components/ChatArea.js
@@ -1,20 +1,35 @@
 // src/components/ChatArea.js - DEPLOYMENT READY (fixes DatabaseOff issue)
 
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Send, Loader2, Database, BookOpen } from 'lucide-react';
 
 const ChatArea = ({
   messages,
-  inputMessage,
-  setInputMessage,
+  onSendMessage,
   isLoading,
-  handleSendMessage,
-  handleKeyPress,
-  messagesEndRef,
   ragEnabled,
   setRAGEnabled,
-  isSaving
+  isSaving = false
 }) => {
+  const [inputMessage, setInputMessage] = useState('');
+  const messagesEndRef = useRef(null);
+
+  const handleSendMessage = () => {
+    if (!inputMessage.trim()) return;
+    onSendMessage(inputMessage);
+    setInputMessage('');
+  };
+
+  const handleKeyPress = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  };
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
   return (
     <div className="h-full flex flex-col bg-white rounded-lg shadow-sm border border-gray-200">
       {/* Chat Header with RAG Toggle */}


### PR DESCRIPTION
## Summary
- manage ChatArea text input internally and scroll to bottom on new messages
- call parent send callback after submitting and reset input

## Testing
- `npm test -- --watchAll=false` *(fails: handleAddTrainingResource is not a function; Cannot find module '@auth0/auth0-react')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c24a19ac832a9502afb81e6d8ae9