### PR TITLE
fix: ensure logout initializes Auth0 client

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -217,6 +217,15 @@ class AuthService {
   }
 
   async logout() {
+    // Ensure the Auth0 client is initialized before attempting logout
+    if (!this.auth0Client) {
+      try {
+        await this.initialize();
+      } catch (initError) {
+        console.error('Auth0 initialization failed during logout:', initError);
+      }
+    }
+
     if (!this.auth0Client) {
       throw new Error('Auth0 client not initialized');
     }
@@ -225,7 +234,7 @@ class AuthService {
       // Clear cached token
       this.cachedToken = null;
       this.tokenExpiry = null;
-      
+
       await this.auth0Client.logout({
         logoutParams: {
           returnTo: AUTH0_CONFIG.LOGOUT_URI


### PR DESCRIPTION
## Summary
- safeguard sign-out by initializing Auth0 client before logout

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c168d7e008832aaa997b2cf174a807