### PR TITLE
Wrap app with Auth0Provider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
 import './index.css';
 import App from './App';
+import { AUTH0_CONFIG } from './config/constants';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <Auth0Provider
+    domain={AUTH0_CONFIG.DOMAIN}
+    clientId={AUTH0_CONFIG.CLIENT_ID}
+    authorizationParams={{
+      redirect_uri: AUTH0_CONFIG.REDIRECT_URI,
+      audience: AUTH0_CONFIG.AUDIENCE,
+      scope: AUTH0_CONFIG.SCOPE,
+    }}
+  >
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  </Auth0Provider>,
 );
+


### PR DESCRIPTION
## Summary
- Wrap root component with Auth0Provider to supply Auth0 context
- Configure provider with domain, client id, audience and scope

## Testing
- `npm test -- --runTestsByPath src/services/authService.test.js` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c17824ab58832aa6968a0fbf14cfee