### PR TITLE
Ensure logout redirects to landing page

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -240,6 +240,8 @@ class AuthService {
           returnTo: AUTH0_CONFIG.LOGOUT_URI
         }
       });
+      // Ensure the browser returns to the landing page after logging out
+      window.location.assign(AUTH0_CONFIG.LOGOUT_URI);
     } catch (error) {
       console.error('Logout error:', error);
       throw new Error('Failed to logout');


### PR DESCRIPTION
## Summary
- Force a browser redirect after Auth0 logout to return users to the landing page

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@auth0%2fauth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c17be69df4832aa81443285a513652