### PR TITLE
Ensure environment config validation halts on misconfiguration

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -133,7 +133,7 @@ export const validateEnvironment = () => {
     const value = process.env[varName];
     return !value || value.trim() === '' || value === 'your_value_here';
   });
-  
+
   if (missing.length > 0) {
     console.error('❌ CONFIGURATION ERROR: Missing required environment variables:');
     missing.forEach(varName => {
@@ -149,15 +149,15 @@ export const validateEnvironment = () => {
     console.error('• OpenAI API Keys: https://platform.openai.com/account/api-keys');
     console.error('• Auth0 Dashboard: https://manage.auth0.com/');
     console.error('• Netlify Environment Variables: https://docs.netlify.com/configure-builds/environment-variables/');
-    
-    return false;
+
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
   }
   
   // Validate Auth0 domain format
   if (AUTH0_CONFIG.DOMAIN && !AUTH0_CONFIG.DOMAIN.includes('.auth0.com')) {
     console.error('❌ CONFIGURATION ERROR: Invalid Auth0 domain format');
     console.error('   Expected format: your-tenant.auth0.com or your-tenant.us.auth0.com');
-    return false;
+    throw new Error('Invalid Auth0 domain format');
   }
   
   // Validate OpenAI API key format
@@ -165,9 +165,9 @@ export const validateEnvironment = () => {
   if (apiKey && !apiKey.startsWith('sk-')) {
     console.error('❌ CONFIGURATION ERROR: Invalid OpenAI API key format');
     console.error('   Expected format: sk-proj-... or sk-...');
-    return false;
+    throw new Error('Invalid OpenAI API key format');
   }
-  
+
   console.log('✅ Environment validation passed');
   return true;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,10 @@ import ReactDOM from 'react-dom/client';
 import { Auth0Provider } from '@auth0/auth0-react';
 import './index.css';
 import App from './App';
-import { AUTH0_CONFIG } from './config/constants';
+import { AUTH0_CONFIG, validateEnvironment } from './config/constants';
+
+// Validate required environment configuration before app initialization
+validateEnvironment();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 


### PR DESCRIPTION
## Summary
- Throw explicit errors in `validateEnvironment` when required env vars are missing or malformed
- Run environment validation during app startup to prevent misconfigured builds

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `node -e "global.window={location:{origin:'http://localhost'}};process.env.REACT_APP_AUTH0_CLIENT_ID='id';process.env.REACT_APP_OPENAI_API_KEY='sk-test';require('./src/config/constants').validateEnvironment();"`

------
https://chatgpt.com/codex/tasks/task_e_68c183ce4148832a9b5b32719eb8ff3a