### PR TITLE
Gate unauthenticated users with AuthScreen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Header from './components/Header';
 import ChatInterface from './components/ChatArea';
 import AdminScreen from './components/AdminScreen';
 import ResourcesView from './components/ResourcesView';
+import AuthScreen from './components/AuthScreen';
 
 // Services
 import learningSuggestionsService from './services/learningSuggestionsService';
@@ -221,6 +222,10 @@ function App() {
       </div>
     );
   };
+
+  if (!isAuthenticated) {
+    return <AuthScreen />;
+  }
 
   return (
     <div className="flex h-screen bg-gray-50">


### PR DESCRIPTION
## Summary
- show AuthScreen for visitors who are not authenticated
- import AuthScreen component in App

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for @auth0/auth0-react)*
- `npm start` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19cfd1f3c832a9ed7a51a6791070c