### PR TITLE
Fix login button to trigger Auth0 redirect

### DIFF
--- a/src/components/AuthScreen.js
+++ b/src/components/AuthScreen.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { handleLogin } from '../services/authService';
+import { useAuth0 } from '@auth0/auth0-react';
 
 const AuthScreen = () => {
+  const { loginWithRedirect } = useAuth0();
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white flex items-center justify-center">
       <div className="text-center space-y-6">
@@ -14,7 +16,7 @@ const AuthScreen = () => {
         />
         <p className="text-lg text-gray-300">Sign in to continue</p>
         <button
-          onClick={handleLogin}
+          onClick={() => loginWithRedirect()}
           className="px-6 py-3 bg-primary text-white rounded-md hover:bg-primary-dark focus:outline-none"
         >
           Log In


### PR DESCRIPTION
## Summary
- Use Auth0 `loginWithRedirect` hook in `AuthScreen` login button

## Testing
- `npm test --silent -- --watchAll=false` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a304420832a806e952605bdcea5