### PR TITLE
Refactor learning suggestions auth flow

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,10 @@ import learningSuggestionsService from './services/learningSuggestionsService';
 function App() {
   const { isAuthenticated, user, getAccessTokenSilently } = useAuth0();
 
+  // Provide the Auth0 token retrieval function to the learning suggestions service
+  // so that it can authenticate its requests without managing Auth0 directly.
+  learningSuggestionsService.setTokenProvider(getAccessTokenSilently);
+
   // Conversation state
   const [messages, setMessages] = useState([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -24,6 +24,8 @@ import learningSuggestionsService from '../services/learningSuggestionsService';
 
 const AdminScreen = ({ onClose }) => {
   const { user, getAccessTokenSilently } = useAuth0();
+  // Ensure the learning suggestions service can obtain tokens
+  learningSuggestionsService.setTokenProvider(getAccessTokenSilently);
   const [activeTab, setActiveTab] = useState('overview');
   const [isLoading, setIsLoading] = useState(false);
   const [systemStatus, setSystemStatus] = useState({});


### PR DESCRIPTION
## Summary
- inject token provider into learning suggestions service
- supply Auth0's `getAccessTokenSilently` as the token provider in App and Admin screens

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a113eba4832a8a53ce4d661144b2