### PR TITLE
Include x-user-id in neon-db requests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -86,7 +86,7 @@ function App() {
   // Load learning configuration
   const loadLearningConfig = async () => {
     try {
-      const config = await learningSuggestionsService.getAdminConfig();
+      const config = await learningSuggestionsService.getAdminConfig(user.sub);
       setLearningConfig((prev) => ({ ...prev, ...config }));
     } catch (err) {
       console.error('Error loading learning config:', err);
@@ -102,7 +102,8 @@ function App() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
+          Authorization: `Bearer ${token}`,
+          'x-user-id': user.sub
         },
         body: JSON.stringify({
           action: 'get_conversations',
@@ -130,7 +131,8 @@ function App() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`
+          Authorization: `Bearer ${token}`,
+          'x-user-id': user.sub
         },
         body: JSON.stringify({
           action: conversationId ? 'update_conversation' : 'save_conversation',

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -53,7 +53,8 @@ const AdminScreen = ({ onClose }) => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Authorization': `Bearer ${token}`,
+          'x-user-id': user.sub
         },
         body: JSON.stringify({
           action: 'get_system_status'
@@ -73,7 +74,7 @@ const AdminScreen = ({ onClose }) => {
 
   const loadLearningConfig = async () => {
     try {
-      const config = await learningSuggestionsService.getAdminConfig();
+      const config = await learningSuggestionsService.getAdminConfig(user.sub);
       setLearningConfig(prev => ({
         ...prev,
         ...config
@@ -86,7 +87,7 @@ const AdminScreen = ({ onClose }) => {
   const saveLearningConfig = async () => {
     setIsLoading(true);
     try {
-      const success = await learningSuggestionsService.updateAdminConfig(learningConfig);
+      const success = await learningSuggestionsService.updateAdminConfig(learningConfig, user.sub);
       if (success) {
         setConfigSaved(true);
         setTimeout(() => setConfigSaved(false), 3000);

--- a/src/services/learningSuggestionsService.js
+++ b/src/services/learningSuggestionsService.js
@@ -39,7 +39,7 @@ class LearningSuggestionsService {
       console.log('🎓 Getting learning suggestions for user:', userId);
 
       // Get admin configuration for chat count
-      const adminConfig = await this.getAdminConfig();
+      const adminConfig = await this.getAdminConfig(userId);
       const analysisCount = chatCount || adminConfig.learningChatCount || this.defaultChatCount;
       
       console.log(`📊 Analyzing last ${analysisCount} conversations for learning suggestions`);
@@ -100,7 +100,8 @@ class LearningSuggestionsService {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Authorization': `Bearer ${token}`,
+          'x-user-id': userId
         },
         body: JSON.stringify({
           action: 'get_recent_conversations',
@@ -383,14 +384,15 @@ Return the response in valid JSON format as an array of suggestion objects.`;
   /**
    * Get admin configuration including chat count for learning suggestions
    */
-  async getAdminConfig() {
+  async getAdminConfig(userId) {
     try {
       const token = await this.getAuthToken();
       const response = await fetch(this.apiUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Authorization': `Bearer ${token}`,
+          'x-user-id': userId
         },
         body: JSON.stringify({
           action: 'get_admin_config',
@@ -415,14 +417,15 @@ Return the response in valid JSON format as an array of suggestion objects.`;
   /**
    * Update admin configuration for learning suggestions
    */
-  async updateAdminConfig(config) {
+  async updateAdminConfig(config, userId) {
     try {
       const token = await this.getAuthToken();
       const response = await fetch(this.apiUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          'Authorization': `Bearer ${token}`,
+          'x-user-id': userId
         },
         body: JSON.stringify({
           action: 'update_admin_config',


### PR DESCRIPTION
## Summary
- Attach `x-user-id` header for learningSuggestionsService Neon DB operations
- Pass user id in App and AdminScreen Neon DB fetches and admin config calls

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f3c9f36c832aaa8e650b309cd6ff