### PR TITLE
Refactor Neon API calls to use service layer

### DIFF
--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -21,6 +21,7 @@ import {
   Unlock
 } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';
+import neonService from '../services/neonService';
 
 const AdminScreen = ({ onClose }) => {
   const { user, getAccessTokenSilently } = useAuth0();
@@ -47,23 +48,8 @@ const AdminScreen = ({ onClose }) => {
   const loadSystemStatus = async () => {
     setIsLoading(true);
     try {
-      // Load system health status
-      const token = await getAccessTokenSilently();
-      const response = await fetch('/.netlify/functions/neon-db', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify({
-          action: 'get_system_status'
-        })
-      });
-
-      if (response.ok) {
-        const result = await response.json();
-        setSystemStatus(result.status);
-      }
+      const status = await neonService.getSystemStatus();
+      setSystemStatus(status);
     } catch (error) {
       console.error('Error loading system status:', error);
     } finally {

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -413,6 +413,22 @@ class NeonService {
   }
 
   /**
+   * Load overall system status information
+   */
+  async getSystemStatus() {
+    try {
+      const result = await this.makeAuthenticatedRequest(this.apiUrl, {
+        method: 'POST',
+        body: JSON.stringify({ action: 'get_system_status' })
+      });
+      return result.status || {};
+    } catch (error) {
+      console.error('Failed to load system status:', error);
+      return {};
+    }
+  }
+
+  /**
    * Check if the service is available
    */
   async isServiceAvailable() {
@@ -520,6 +536,9 @@ export const autoSaveConversation = (messages, metadata) =>
 
 export const getConversationStats = () =>
   neonService.getConversationStats();
+
+export const getSystemStatus = () =>
+  neonService.getSystemStatus();
 
 export const isServiceAvailable = () =>
   neonService.isServiceAvailable();


### PR DESCRIPTION
## Summary
- Route conversation save/load through neonService instead of manual fetch
- Add getSystemStatus to neonService and consume it from AdminScreen
- Initialize neonService during auth flow to remove duplicate token logic

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for @auth0/auth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f3cc0298832a96c475457764535d