### PR TITLE
Specify Auth0 audience and document x-user-id fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ http://localhost:3000, https://your-app.netlify.app
 
 **Note:** `REACT_APP_AUTH0_ROLES_CLAIM` must match the custom claim added by your Auth0 Action/Rule.
 
+### Token Fallback Behaviour
+
+When requesting access tokens, the application now specifies the API audience so Auth0 returns a JWT containing the `sub` claim.  
+If a JWT cannot be decoded client‑side (for example, encrypted JWE tokens), requests must include an `x-user-id` header with the user's `sub`.  
+All API calls will attempt to proceed even when an access token is unavailable, allowing backend functions to fall back to the `x-user-id` header.
+
 ### 5. Development
 ```bash
 npm start

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -21,6 +21,7 @@ import {
   Unlock
 } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';
+import { AUTH0_CONFIG } from '../config/constants';
 
 const AdminScreen = ({ onClose }) => {
   const { user, getAccessTokenSilently } = useAuth0();
@@ -48,13 +49,28 @@ const AdminScreen = ({ onClose }) => {
     setIsLoading(true);
     try {
       // Load system health status
-      const token = await getAccessTokenSilently();
+      let token = null;
+      try {
+        token = await getAccessTokenSilently({
+          authorizationParams: { audience: AUTH0_CONFIG.AUDIENCE }
+        });
+      } catch (err) {
+        console.warn('Token retrieval failed for loadSystemStatus:', err.message);
+      }
+
+      const headers = {
+        'Content-Type': 'application/json'
+      };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+      if (user?.sub) {
+        headers['x-user-id'] = user.sub;
+      }
+
       const response = await fetch('/.netlify/functions/neon-db', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers,
         body: JSON.stringify({
           action: 'get_system_status'
         })

--- a/src/services/neonService.js
+++ b/src/services/neonService.js
@@ -42,30 +42,26 @@ class NeonService {
         token = await getToken();
         console.log('Token retrieved:', !!token);
         console.log('Token length:', token?.length || 0);
-        
+
         if (token) {
           defaultHeaders['Authorization'] = `Bearer ${token}`;
           console.log('Added Authorization header');
         }
       } catch (tokenError) {
-        console.error('Failed to get token:', tokenError);
-        throw new Error(`Authentication failed: ${tokenError.message}`);
+        console.warn('Failed to get token:', tokenError);
       }
 
       try {
         // Get user ID using the new helper function
         userId = await getUserId();
         console.log('User ID retrieved:', userId ? userId.substring(0, 10) + '...' : 'null');
-        
+
         if (userId) {
           defaultHeaders['x-user-id'] = userId;
           console.log('Added x-user-id header');
-        } else {
-          throw new Error('User ID not available');
         }
       } catch (userIdError) {
-        console.error('Failed to get user ID:', userIdError);
-        throw new Error(`User identification failed: ${userIdError.message}`);
+        console.warn('Failed to get user ID:', userIdError);
       }
 
       // Fallback to stored user ID if available


### PR DESCRIPTION
## Summary
- Request Auth0 access tokens with API audience so returned JWTs include `sub`
- Include `x-user-id` headers and proceed when tokens are missing or undecodable
- Document token fallback behavior in README

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching @auth0/auth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f3ccf99c832ab40e017e014baec1