### PR TITLE
Fix undefined token when loading or saving conversations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -98,6 +98,7 @@ function App() {
   const loadConversations = async () => {
     if (!isAuthenticated || !user) return;
     try {
+      const token = await getAccessTokenSilently();
       const result = await neonService.makeAuthenticatedRequest('/.netlify/functions/neon-db', {
         method: 'POST',
 
@@ -125,6 +126,7 @@ function App() {
   const saveConversation = async (msgs, conversationId = null, isNewConversation = false) => {
     if (!isAuthenticated || !user || msgs.length === 0) return null;
     try {
+      const token = await getAccessTokenSilently();
       await neonService.makeAuthenticatedRequest('/.netlify/functions/neon-db', {
         method: 'POST',
 


### PR DESCRIPTION
## Summary
- Retrieve access token before Neon API requests in `App` to prevent `token is not defined` errors

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2066fb654832ab4d986d582c40651