### PR TITLE
Fix login button to trigger Auth0 redirect

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import AdminScreen from './components/AdminScreen';
 import EvaluationModal from './components/EvaluationModal';
 import openaiService from './services/openaiService';
 import neonService from './services/neonService';
-import { initializeAuth, logout, validateEnvironment, getUser } from './services/authService';
+import { initializeAuth, login, logout, validateEnvironment } from './services/authService';
 import { hasAdminRole } from './utils/auth';
 import { mergeCurrentAndStoredMessages, validateAndRepairMessages } from './utils/messageUtils';
 
@@ -374,7 +374,7 @@ function App() {
               Your AI-powered pharmaceutical quality and compliance assistant
             </p>
             <button
-              onClick={() => initializeAuth(setUser, setIsLoadingAuth)}
+              onClick={login}
               className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg hover:bg-blue-700 transition-colors font-medium"
             >
               Sign In to Continue


### PR DESCRIPTION
## Summary
- Call Auth0 `login` on sign-in button so users are redirected to Auth0 instead of reinitializing client
- Import `login` helper alongside existing auth service utilities

## Testing
- `npm test` *(fails: react-scripts: not found)*
- `npm install` *(fails: 403 Forbidden fetching @auth0/auth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c217326ab8832a9f13850e71af18db