### PR TITLE
fix: resolve Auth0 login state mismatch

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -388,9 +388,9 @@ function App() {
   // Admin screen
   if (showAdmin) {
     return (
-      <AdminScreen 
-        user={user} 
-        onBack={handleCloseAdmin}
+      <AdminScreen
+        user={user}
+        onClose={handleCloseAdmin}
       />
     );
   }

--- a/src/components/AdminScreen.js
+++ b/src/components/AdminScreen.js
@@ -1,6 +1,5 @@
 // src/components/AdminScreen.js - ENHANCED WITH LEARNING CENTER CONFIG
 import React, { useState, useEffect } from 'react';
-import { useAuth0 } from '@auth0/auth0-react';
 import { 
   Settings, 
   Database, 
@@ -22,11 +21,11 @@ import {
 } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';
 import neonService from '../services/neonService';
+import { getToken } from '../services/authService';
 
-const AdminScreen = ({ onClose }) => {
-  const { user, getAccessTokenSilently } = useAuth0();
+const AdminScreen = ({ user, onClose }) => {
   // Ensure the learning suggestions service can obtain tokens
-  learningSuggestionsService.setTokenProvider(getAccessTokenSilently);
+  learningSuggestionsService.setTokenProvider(getToken);
   const [activeTab, setActiveTab] = useState('overview');
   const [isLoading, setIsLoading] = useState(false);
   const [systemStatus, setSystemStatus] = useState({});
@@ -53,7 +52,7 @@ const AdminScreen = ({ onClose }) => {
       setSystemStatus(status);
 
       // Load system health status
-      const token = await getAccessTokenSilently();
+      const token = await getToken();
       const response = await fetch('/.netlify/functions/neon-db', {
         method: 'POST',
         headers: {

--- a/src/components/AdminScreen.test.js
+++ b/src/components/AdminScreen.test.js
@@ -63,7 +63,7 @@ describe('AdminScreen navigation', () => {
     const user = { roles: ['admin'] };
 
     await act(async () => {
-      ReactDOM.render(<AdminScreen user={user} onBack={() => {}} />, container);
+      ReactDOM.render(<AdminScreen user={user} onClose={() => {}} />, container);
     });
 
     const ragButton = Array.from(container.querySelectorAll('button')).find(btn =>

--- a/src/components/AuthScreen.js
+++ b/src/components/AuthScreen.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { useAuth0 } from '@auth0/auth0-react';
+import { login } from '../services/authService';
 
 const AuthScreen = () => {
-  const { loginWithRedirect } = useAuth0();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white flex items-center justify-center">
@@ -16,7 +15,7 @@ const AuthScreen = () => {
         />
         <p className="text-lg text-gray-300">Sign in to continue</p>
         <button
-          onClick={() => loginWithRedirect()}
+          onClick={login}
           className="px-6 py-3 bg-primary text-white rounded-md hover:bg-primary-dark focus:outline-none"
         >
           Log In

--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -1,6 +1,5 @@
 // src/components/ResourcesView.js - ENHANCED WITH AI LEARNING SUGGESTIONS
 import React, { useState, useEffect } from 'react';
-import { useAuth0 } from '@auth0/auth0-react';
 import { 
   BookOpen, 
   ExternalLink, 
@@ -18,8 +17,7 @@ import {
 } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';
 
-const ResourcesView = ({ learningSuggestions = [], onRefreshSuggestions }) => {
-  const { user, isAuthenticated } = useAuth0();
+const ResourcesView = ({ user, learningSuggestions = [], onRefreshSuggestions }) => {
   const [activeTab, setActiveTab] = useState('ai-suggestions');
   const [suggestions, setSuggestions] = useState(learningSuggestions);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
@@ -73,7 +71,7 @@ const ResourcesView = ({ learningSuggestions = [], onRefreshSuggestions }) => {
   }, [learningSuggestions]);
 
   const handleRefreshSuggestions = async () => {
-    if (!isAuthenticated || !user) return;
+    if (!user) return;
 
     setIsLoadingSuggestions(true);
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { Auth0Provider } from '@auth0/auth0-react';
 import './index.css';
 import App from './App';
-import { AUTH0_CONFIG, validateEnvironment } from './config/constants';
+import { validateEnvironment } from './config/constants';
 
 // Validate required environment configuration before app initialization
 validateEnvironment();
@@ -11,18 +10,8 @@ validateEnvironment();
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
 root.render(
-  <Auth0Provider
-    domain={AUTH0_CONFIG.DOMAIN}
-    clientId={AUTH0_CONFIG.CLIENT_ID}
-    authorizationParams={{
-      redirect_uri: AUTH0_CONFIG.REDIRECT_URI,
-      audience: AUTH0_CONFIG.AUDIENCE,
-      scope: AUTH0_CONFIG.SCOPE,
-    }}
-  >
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  </Auth0Provider>,
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
 );
 


### PR DESCRIPTION
## Summary
- remove redundant `Auth0Provider` to prevent double Auth0 initialization
- refactor components to use shared auth service instead of `useAuth0`
- update admin and resource views to accept user prop and fetch tokens via service

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden for @auth0/auth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bfbddcdc832aaf810956e4a40c34