### PR TITLE
fix: set token provider for learning suggestions

### DIFF
--- a/src/components/ResourcesView.js
+++ b/src/components/ResourcesView.js
@@ -16,12 +16,18 @@ import {
   Award
 } from 'lucide-react';
 import learningSuggestionsService from '../services/learningSuggestionsService';
+import { getToken } from '../services/authService';
 
 const ResourcesView = ({ user, learningSuggestions = [], onRefreshSuggestions }) => {
   const [activeTab, setActiveTab] = useState('ai-suggestions');
   const [suggestions, setSuggestions] = useState(learningSuggestions);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(null);
+
+  // Ensure the service can obtain auth tokens
+  useEffect(() => {
+    learningSuggestionsService.setTokenProvider(getToken);
+  }, []);
 
   // Static learning resources
   const staticResources = [


### PR DESCRIPTION
## Summary
- ensure ResourcesView configures learningSuggestionsService with an auth token provider so refreshing suggestions works

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden retrieving @auth0/auth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c33f3482e0832aa807a4764f9ae8f5