### PR TITLE
Add Auth0 audience validation and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ REACT_APP_AUTH0_CLIENT_ID=your_client_id_here
 # Auth0 Configuration (Optional)
 # Only needed if you're using Auth0 APIs
 REACT_APP_AUTH0_AUDIENCE=your_api_audience_here
+AUTH0_AUDIENCE=your_api_audience_here
 REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 
 # Neon PostgreSQL Database Configuration (Required for persistent storage and Netlify functions)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ REACT_APP_AUTH0_CLIENT_ID=your_client_id
 
 # Auth0 (Optional)
 REACT_APP_AUTH0_AUDIENCE=your_api_audience
+AUTH0_AUDIENCE=your_api_audience
 REACT_APP_AUTH0_ROLES_CLAIM=https://your-domain.com/roles
 
 # Neon PostgreSQL (Required for database features)

--- a/netlify/functions/neon-db.js
+++ b/netlify/functions/neon-db.js
@@ -4,6 +4,11 @@ const { neon } = require('@neondatabase/serverless');
 const jwt = require('jsonwebtoken');
 const jwksClient = require('jwks-rsa');
 
+const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
+if (!AUTH0_AUDIENCE) {
+  throw new Error('AUTH0_AUDIENCE environment variable is not set');
+}
+
 // CORS headers
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -42,7 +47,7 @@ const verifyToken = (token) => {
     }
 
     jwt.verify(token, getKey, {
-      audience: process.env.AUTH0_AUDIENCE,
+      audience: AUTH0_AUDIENCE,
       issuer: `https://${process.env.AUTH0_DOMAIN}/`,
       algorithms: ['RS256']
     }, (err, decoded) => {


### PR DESCRIPTION
## Summary
- validate AUTH0_AUDIENCE at Netlify function startup
- document AUTH0_AUDIENCE env var for local and Netlify builds

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching @auth0/auth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68c3437ffd78832ab238f4c5d18b6364